### PR TITLE
Retry on 429 rate limit errors

### DIFF
--- a/packages/api/__tests__/APIClient.test.ts
+++ b/packages/api/__tests__/APIClient.test.ts
@@ -5,139 +5,162 @@ import APIClient from '../src/APIClient'
 const mock = new MockAdapter(axios) // set mock adapter on default axios instance
 
 describe('@freshbooks/api', () => {
-	describe('Client', () => {
-		test('Default init', () => {
-			const token = 'token'
-			const client = new APIClient(token)
-			expect(client).not.toBeNull()
-		})
+    describe('Client', () => {
+        test('Default init', () => {
+            const token = 'token'
+            const client = new APIClient(token)
+            expect(client).not.toBeNull()
+        })
 
-		test('Test unauthorized request', async () => {
-			mock
-				.onGet('/auth/api/v1/users/me')
-				.replyOnce(
-					401,
-					'{"error":"unauthenticated","error_description":"This action requires authentication to continue."}'
-				)
+        test('Test unauthorized request', async () => {
+            mock
+                .onGet('/auth/api/v1/users/me')
+                .replyOnce(
+                    401,
+                    '{"error":"unauthenticated","error_description":"This action requires authentication to continue."}'
+                )
 
-			const client = new APIClient('foo')
-			try {
-				await client.users.me()
-			} catch (err) {
-				expect(err.code).toEqual('unauthenticated')
-				expect(err.message).toEqual(
-					'This action requires authentication to continue.'
-				)
-			}
-		})
+            const client = new APIClient('foo')
+            try {
+                await client.users.me()
+            } catch (err) {
+                expect(err.code).toEqual('unauthenticated')
+                expect(err.message).toEqual(
+                    'This action requires authentication to continue.'
+                )
+            }
+        })
 
-		test('Test freshbook API errors', async () => {
-			const mockResponse = JSON.stringify({
-				response: {
-					errors: [
-						{
-							message:
-								'The server could not verify that you are authorized to access the URL requested.',
-							errno: 1003,
-						},
-					],
-				},
-			})
-			mock
-				.onGet('/accounting/account/zDmNq/invoices/invoices')
-				.replyOnce(401, mockResponse)
+        test('Test freshbook API errors', async () => {
+            const mockResponse = JSON.stringify({
+                response: {
+                    errors: [
+                        {
+                            message:
+                                'The server could not verify that you are authorized to access the URL requested.',
+                            errno: 1003,
+                        },
+                    ],
+                },
+            })
+            mock
+                .onGet('/accounting/account/zDmNq/invoices/invoices')
+                .replyOnce(401, mockResponse)
 
-			const client = new APIClient('foo')
-			try {
-				await client.invoices.list('zDmNq')
-			} catch (error) {
-				expect(error.name).toEqual('List Invoices')
-				expect(error.code).toEqual('401')
-				expect(error.errors).toEqual([
-					{
-						number: 1003,
-						message:
-							'The server could not verify that you are authorized to access the URL requested.',
-					},
-				])
-			}
-		})
+            const client = new APIClient('foo')
+            try {
+                await client.invoices.list('zDmNq')
+            } catch (error) {
+                expect(error.name).toEqual('List Invoices')
+                expect(error.code).toEqual('401')
+                expect(error.errors).toEqual([
+                    {
+                        number: 1003,
+                        message:
+                            'The server could not verify that you are authorized to access the URL requested.',
+                    },
+                ])
+            }
+        })
 
-		test('Test not found errors', async () => {
-			const mockResponse = JSON.stringify({
-				// eslint-disable-next-line @typescript-eslint/camelcase
-				error_type: 'not_found',
-				message: 'The requested resource was not found.',
-			})
-			mock
-				.onGet('/accounting/account/zDmNq/invoices/invoices/1')
-				.replyOnce(401, mockResponse)
+        test('Test not found errors', async () => {
+            const mockResponse = JSON.stringify({
+                // eslint-disable-next-line @typescript-eslint/camelcase
+                error_type: 'not_found',
+                message: 'The requested resource was not found.',
+            })
+            mock
+                .onGet('/accounting/account/zDmNq/invoices/invoices/1')
+                .replyOnce(401, mockResponse)
 
-			const client = new APIClient('foo')
-			try {
-				await client.invoices.single('zDmNq', '1')
-			} catch (error) {
-				expect(error.code).toEqual('not_found')
-				expect(error.message).toEqual('The requested resource was not found.')
-			}
-		})
+            const client = new APIClient('foo')
+            try {
+                await client.invoices.single('zDmNq', '1')
+            } catch (error) {
+                expect(error.code).toEqual('not_found')
+                expect(error.message).toEqual('The requested resource was not found.')
+            }
+        })
 
-		test('Test unhandled errors', async () => {
-			const unhandledError = new Error('Unhandled Error!')
-			const client = new APIClient('foo')
+        test('Test unhandled errors', async () => {
+            const unhandledError = new Error('Unhandled Error!')
+            const client = new APIClient('foo')
 
-			// mock list method
-			client.invoices.list = jest.fn(() => {
-				throw unhandledError
-			})
+            // mock list method
+            client.invoices.list = jest.fn(() => {
+                throw unhandledError
+            })
 
-			try {
-				await client.invoices.list('zDmNq')
-			} catch (error) {
-				expect(error).toBe(unhandledError)
-			}
-		})
+            try {
+                await client.invoices.list('zDmNq')
+            } catch (error) {
+                expect(error).toBe(unhandledError)
+            }
+        })
 
-		test('Test failed request retry', async () => {
-			mock
-				.onGet('/auth/api/v1/users/me')
-				.replyOnce(
-					500,
-					'{"error":"internal_server_error","error_description":"internal server error"}'
-				)
-				.onGet('/auth/api/v1/users/me')
-				.replyOnce(
-					200,
-					`{ 
-					"response":{ 
-					   "id":2192788}}`
-				)
+        test('Test failed request retry', async () => {
+            mock
+                .onGet('/auth/api/v1/users/me')
+                .replyOnce(
+                    500,
+                    '{"error":"internal_server_error","error_description":"internal server error"}'
+                )
+                .onGet('/auth/api/v1/users/me')
+                .replyOnce(
+                    200,
+                    `{
+                    "response":{
+                       "id":2192788}}`
+                )
 
-			const client = new APIClient('foo')
-			const res = await client.users.me()
+            const client = new APIClient('foo')
+            const res = await client.users.me()
 
-			expect(res.ok).toBeTruthy()
-			expect(res.error).toBeUndefined()
-			expect(res.data).not.toBeUndefined()
-		})
+            expect(res.ok).toBeTruthy()
+            expect(res.error).toBeUndefined()
+            expect(res.data).not.toBeUndefined()
+        })
 
-		test('Test pagination', async () => {
-			const accountId = 'xZNQ1X'
-			mock
-				.onGet(`/accounting/account/${accountId}/invoices/invoices`)
-				.replyOnce(
-					200,
-					'{"response":{"result":{"invoices": [],"page": 1,"pages": 1,"per_page": 15,"total": 7}}}'
-				)
+        test('Test rate limited request retry', async () => {
+            mock
+                .onGet('/auth/api/v1/users/me')
+                .replyOnce(
+                    429,
+                    '{"error":"internal_server_error","error_description":"internal server error"}'
+                )
+                .onGet('/auth/api/v1/users/me')
+                .replyOnce(
+                    200,
+                    `{
+                    "response":{
+                       "id":2192788}}`
+                )
 
-			const client = new APIClient('foo')
-			const res = await client.invoices.list('xZNQ1X')
-			expect(res.ok).toBeTruthy()
-			expect(res.data).not.toBeUndefined()
+            const client = new APIClient('foo')
+            const res = await client.users.me()
 
-			if (res.data) {
-				expect(res.data.pages).not.toBeUndefined()
-			}
-		})
-	})
+            expect(res.ok).toBeTruthy()
+            expect(res.error).toBeUndefined()
+            expect(res.data).not.toBeUndefined()
+        })
+
+        test('Test pagination', async () => {
+            const accountId = 'xZNQ1X'
+            mock
+                .onGet(`/accounting/account/${accountId}/invoices/invoices`)
+                .replyOnce(
+                    200,
+                    '{"response":{"result":{"invoices": [],"page": 1,"pages": 1,"per_page": 15,"total": 7}}}'
+                )
+
+            const client = new APIClient('foo')
+            const res = await client.invoices.list('xZNQ1X')
+            expect(res.ok).toBeTruthy()
+            expect(res.data).not.toBeUndefined()
+
+            if (res.data) {
+                expect(res.data.pages).not.toBeUndefined()
+            }
+        })
+    })
 })

--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -55,6 +55,13 @@ export default class APIClient {
 
 	private logger: Logger
 
+    public isNetworkRateLimitOrIdempotentRequestError(error: any) {
+        if (!error.config) {
+            return false;
+        }
+
+        return (error.response.status == 429) || axiosRetry.isNetworkOrIdempotentRequestError(error);
+    }
 	/**
 	 * FreshBooks API client
 	 * @param token Bearer token
@@ -64,7 +71,8 @@ export default class APIClient {
 	constructor(token: string, options?: Options, logger = _logger) {
 		const defaultRetry = {
 			retries: 3,
-			retryDelay: axiosRetry.exponentialDelay, // ~100ms, 200ms, 400ms, 800ms
+            retryDelay: axiosRetry.exponentialDelay, // ~100ms, 200ms, 400ms, 800ms
+            retryCondition: this.isNetworkRateLimitOrIdempotentRequestError // 429, 5xx, or network error
 		}
 		const { apiUrl = API_URL, retryOptions = defaultRetry } = options || {}
 


### PR DESCRIPTION
# Purpose

Retry on 429 rate limit errors. By default axios-retry only retries on 500 errors, network requests, and idempotent requests. This will also do retries on all requests from a rate-limit error.