### PR TITLE
🐛 Fix "In" search filters

### DIFF
--- a/packages/api/__tests__/Builders.test.ts
+++ b/packages/api/__tests__/Builders.test.ts
@@ -24,7 +24,7 @@ describe('@freshbooks/api', () => {
 				})
 				.build()
 			const expected =
-				'search[address_like]=21 Peter Street&search[userid]=1234&search[userids]=1&search[userids]=2&search[userids]=3&search[userids]=4&search[updated_min]=2000-01-01&search[updated_max]=2015-12-15'
+				'search[address_like]=21 Peter Street&search[userid]=1234&search[userids][]=1&search[userids][]=2&search[userids][]=3&search[userids][]=4&search[updated_min]=2000-01-01&search[updated_max]=2015-12-15'
 
 			expect(result).toEqual(expected)
 		})

--- a/packages/api/src/models/builders/SearchQueryBuilder.ts
+++ b/packages/api/src/models/builders/SearchQueryBuilder.ts
@@ -25,7 +25,7 @@ export class SearchQueryBuilder {
 	}
 
 	in(key: string, values: ParamType[]): SearchQueryBuilder {
-		this.queryParams = { ...this.queryParams, [`search[${key}]`]: values }
+		this.queryParams = { ...this.queryParams, [`search[${key}][]`]: values }
 		return this
 	}
 


### PR DESCRIPTION
# Purpose

Search "In" filters were not correctly being generated.

Should be in the form of: `?search[userids][]=1&search[userids][]=2&search[userids][]=3`
Not: `?search[userids]=1&search[userids]23`

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/26