### PR TITLE
🐛 Stop appending '_like' to search queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## @freshbooks/api
 
+### 1.1.3
+
+- `like` filters no longer automatically append `_like` to the search key.
+  Correct key must now be provided.
+- Fix issue where `in` filters were not correctly being generated.
+
+### 1.1.2
+
+- Now retrying on 429 errors on POST, PUT
+- Tune retries to 10 attempts (was 3)
+
 ### 1.1.0
 
 - Added default retries with backoff on failed API calls

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Example API client call with `SearchQueryBuilder`:
 ```typescript
 //create and populate SearchQueryBuilder
 const searchQueryBuilder = new SearchQueryBuilder()
-    .like('address', '200 King Street')
+    .like('address_like', '200 King Street')
     .between('date', { min: new Date('2010-05-06'), max: new Date('2019-11-10') })
 
 try {

--- a/packages/api/__tests__/Builders.test.ts
+++ b/packages/api/__tests__/Builders.test.ts
@@ -15,7 +15,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('SearchQueryBuilder', () => {
 			const result = new SearchQueryBuilder()
-				.like('address', '21 Peter Street')
+				.like('address_like', '21 Peter Street')
 				.equals('userid', 1234)
 				.in('userids', [1, 2, 3, 4])
 				.between('updated', {
@@ -38,7 +38,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('joinQueries', () => {
 			const searchBuilder = new SearchQueryBuilder()
-				.like('address', '21 Peter Street')
+				.like('address_like', '21 Peter Street')
 				.equals('userid', 1234)
 			const includesBuilder = new IncludesQueryBuilder()
 				.includes('lines')

--- a/packages/api/src/models/builders/SearchQueryBuilder.ts
+++ b/packages/api/src/models/builders/SearchQueryBuilder.ts
@@ -35,7 +35,7 @@ export class SearchQueryBuilder {
 	}
 
 	like(key: string, value: ParamType): SearchQueryBuilder {
-		this.queryParams = { ...this.queryParams, [`search[${key}_like]`]: value }
+		this.queryParams = { ...this.queryParams, [`search[${key}]`]: value }
 		return this
 	}
 


### PR DESCRIPTION
# Purpose

Currently the `like` method in SearchQueryBuilder appends `_like` to the end of the key provided.

However, not all the like searches end in like (see most filters in expenses), so always appending to the key will prevent users from using these filters.

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/28