### PR TITLE
🐛 Fix Client Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Unreleased
 
 - Added Project resource
+- Client model fixes
+- Standardize date/time objects to UTC (accounting endpoints return data in EST)
 
 ### 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ console.log(`Showing ${pages.size} per page`)
 console.log(`${pages.size} total invoices`)
 ```
 
+##### Dates and Times
+
+For historical reasons, some resources in the FreshBooks API (mostly accounting-releated) return date/times in "US/Eastern" timezone. Some effort is taken to convert these in the models to return `Date` objects normalized to UTC.
+
 ### `@freshbooks/app`
 
 The FreshBooks SDK provides a pre-configured `ExpressJS` app. This app provides OAuth2 authentication flow, a `PassportJS` middleware for authenticating requests, and session middleware to retrieve tokens for a session.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -188,3 +188,7 @@ console.log(`Page ${pages.page} of ${pages.total} pages`)
 console.log(`Showing ${pages.size} per page`)
 console.log(`${pages.size} total invoices`)
 ```
+
+##### Dates and Times
+
+For historical reasons, some resources in the FreshBooks API (mostly accounting-releated) return date/times in "US/Eastern" timezone. Some effort is taken to convert these in the models to return `Date` objects normalized to UTC.

--- a/packages/api/__tests__/Category.test.ts
+++ b/packages/api/__tests__/Category.test.ts
@@ -6,7 +6,6 @@ describe('@freshbooks/api', () => {
 	describe('Group', () => {
 		test('Verify JSON -> model transform', () => {
 			const json = `{
-                
                 "category": "Car & Truck Expenses",
                 "categoryid": 3012654,
                 "created_at": "2019-06-05 11:42:54",
@@ -22,38 +21,12 @@ describe('@freshbooks/api', () => {
 			const expected = {
 				category: 'Car & Truck Expenses',
 				categoryId: '3012654',
-				createdAt: new Date('2019-06-05 11:42:54'),
+				createdAt: new Date('2019-06-05T15:42:54Z'),
 				id: '3012654',
 				isCogs: false,
 				isEditable: false,
 				parentId: null,
-				updatedAt: new Date('2019-06-05 11:42:54'),
-				visState: 0,
-			}
-			expect(model).toEqual(expected)
-		})
-		test('Verify Category response object -> model transform', () => {
-			const categoryResponse = {
-				category: 'Car & Truck Expenses',
-				categoryid: 3012654,
-				created_at: '2019-06-05 11:42:54',
-				id: 3012654,
-				is_cogs: false,
-				is_editable: false,
-				parentid: null,
-				updated_at: '2019-06-05 11:42:54',
-				vis_state: 0,
-			}
-			const model = transformCategoryResponse(categoryResponse)
-			const expected = {
-				category: 'Car & Truck Expenses',
-				categoryId: '3012654',
-				createdAt: new Date('2019-06-05 11:42:54'),
-				id: '3012654',
-				isCogs: false,
-				isEditable: false,
-				parentId: null,
-				updatedAt: new Date('2019-06-05 11:42:54'),
+				updatedAt: new Date('2019-06-05T15:42:54Z'),
 				visState: 0,
 			}
 			expect(model).toEqual(expected)

--- a/packages/api/__tests__/Client.test.ts
+++ b/packages/api/__tests__/Client.test.ts
@@ -5,6 +5,7 @@ import APIClient, { Options } from '../src/APIClient'
 import { Client } from '../src'
 import { SearchQueryBuilder } from '../src/models/builders/SearchQueryBuilder'
 import { joinQueries } from '../src/models/builders'
+import VisState from '../src/models/VisState'
 
 const mock = new MockAdapter(axios) // set mock adapter on default axios instance
 
@@ -115,15 +116,15 @@ const buildExpectedClientResult = (clientProperties: any = {}): Client => ({
 	sProvince: '',
 	sStreet: '',
 	sStreet2: '',
-	signupDate: '2019-11-18 16:14:18',
+	signupDate: new Date('2019-11-18T16:14:18Z'),
 	statementToken: null,
 	subdomain: null,
-	updated: '2019-11-18 12:04:07',
+	updated: new Date('2019-11-18T17:04:07Z'),
 	userId: CLIENT_ID,
 	username: 'johnnyappleseed2',
 	vatName: null,
 	vatNumber: null,
-	visState: 0,
+	visState: VisState.active,
 	...clientProperties,
 })
 

--- a/packages/api/__tests__/Expense.test.ts
+++ b/packages/api/__tests__/Expense.test.ts
@@ -87,7 +87,7 @@ const buildExpense = (expenseProperties: any = {}): Expense => ({
 	taxPercent1: 0,
 	taxPercent2: 0,
 	transactionId: null,
-	updated: new Date('Mon Dec 02 2019 12:36:05'),
+	updated: new Date('2019-12-02T17:36:05Z'),
 	vendor: null,
 	visState: 0,
 	...expenseProperties,
@@ -138,7 +138,7 @@ describe('@freshbooks/api', () => {
 			const token = 'token'
 			const client = new APIClient(token, testOptions)
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "expense": ${buildMockResponse()}
@@ -158,7 +158,7 @@ describe('@freshbooks/api', () => {
 			const token = 'token'
 			const client = new APIClient(token, testOptions)
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "expenses": [${buildMockResponse()}],
@@ -202,7 +202,7 @@ describe('@freshbooks/api', () => {
 				vis_state: 0,
 			}
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "expenses": [
@@ -239,7 +239,7 @@ describe('@freshbooks/api', () => {
 			const token = 'token'
 			const client = new APIClient(token, testOptions)
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "expenses": [${buildMockResponse()}],
@@ -275,7 +275,7 @@ describe('@freshbooks/api', () => {
 			const token = 'token'
 			const client = new APIClient(token, testOptions)
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "expense": ${buildMockResponse()}
@@ -297,7 +297,7 @@ describe('@freshbooks/api', () => {
 			const token = 'token'
 			const client = new APIClient(token, testOptions)
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "expense": ${buildMockResponse()}
@@ -322,7 +322,7 @@ describe('@freshbooks/api', () => {
 			const client = new APIClient(token, testOptions)
 
 			const mockResponse = `
-            {"response": 
+            {"response":
                 {
                     "result": {
                         "expense": ${buildMockResponse({ vis_state: 1 })}

--- a/packages/api/__tests__/Invoice.test.ts
+++ b/packages/api/__tests__/Invoice.test.ts
@@ -356,7 +356,7 @@ describe('@freshbooks/api', () => {
 									amount: '5000.00',
 									code: 'USD',
 								},
-								updated: new Date('2019-11-25 15:43:26'),
+								updated: new Date('2019-11-25T20:43:26Z'),
 							},
 						],
 					}),

--- a/packages/api/__tests__/Invoice.test.ts
+++ b/packages/api/__tests__/Invoice.test.ts
@@ -106,7 +106,7 @@ const buildInvoice = (invoiceProperties: any = {}): Invoice => ({
 	code: 'M5V0P3',
 	country: 'Canada',
 	createDate: new Date('2019-11-14'.concat(' 00:00:00')),
-	createdAt: new Date('2019-11-14 11:27:45'),
+	createdAt: new Date('2019-11-14T16:27:45Z'),
 	currencyCode: 'USD',
 	currentOrganization: 'Hooli',
 	customerId: 217572,
@@ -162,7 +162,7 @@ const buildInvoice = (invoiceProperties: any = {}): Invoice => ({
 	street2: '',
 	template: 'clean-grouped',
 	terms: null,
-	updated: new Date('2019-11-14 11:27:45'),
+	updated: new Date('2019-11-14T16:27:45Z'),
 	v3Status: 'draft',
 	vatName: null,
 	vatNumber: '',
@@ -224,7 +224,7 @@ describe('@freshbooks/api', () => {
 			const INVOICE_ID = '217506'
 
 			const mockResponse = `
-            {"response": 
+            {"response":
                 {
                     "result": {
                         "invoice": ${buildMockResponse()}
@@ -243,7 +243,7 @@ describe('@freshbooks/api', () => {
 			const client = new Client(token, testOptions)
 
 			const mockResponse = `
-                {"response": 
+                {"response":
                     {
                         "result": {
                             "invoices": [
@@ -276,7 +276,7 @@ describe('@freshbooks/api', () => {
 			const client = new Client(token, testOptions)
 
 			const mockResponse = `
-                {"response": 
+                {"response":
                     {
                         "result": {
                             "invoices": [
@@ -378,7 +378,7 @@ describe('@freshbooks/api', () => {
 			const client = new Client(token, testOptions)
 
 			const mockResponse = `
-                {"response": 
+                {"response":
                     {
                         "result": {
                             "invoices": [
@@ -411,7 +411,7 @@ describe('@freshbooks/api', () => {
 			const token = 'token'
 			const client = new Client(token, testOptions)
 			const mockResponse = `
-            {"response": 
+            {"response":
                 {
                     "result": {
                         "invoice": ${buildMockResponse()}
@@ -432,7 +432,7 @@ describe('@freshbooks/api', () => {
 			const INVOICE_ID = '217506'
 
 			const mockResponse = `
-            {"response": 
+            {"response":
                 {
                     "result": {
                         "invoice": ${buildMockResponse()}
@@ -455,7 +455,7 @@ describe('@freshbooks/api', () => {
 			const INVOICE_ID = '217506'
 
 			const mockResponse = `
-            {"response": 
+            {"response":
                 {
                     "result": {
                         "invoice": ${buildMockResponse({ vis_state: 1 })}

--- a/packages/api/__tests__/Payment.test.ts
+++ b/packages/api/__tests__/Payment.test.ts
@@ -77,7 +77,7 @@ const buildPayment = (paymentProperties: any = {}): Payment => ({
 	overpaymentId: null,
 	transactionId: null,
 	type: 'Cash',
-	updated: new Date('2019-11-29 12:18:29'),
+	updated: new Date('2019-11-29T17:18:29Z'),
 	visState: 0,
 	...paymentProperties,
 })
@@ -88,7 +88,7 @@ describe('@freshbooks/api', () => {
 			const token = 'token'
 			const client = new APIClient(token, testOptions)
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "payment": ${buildMockResponse()}
@@ -108,7 +108,7 @@ describe('@freshbooks/api', () => {
 			const token = 'token'
 			const client = new APIClient(token, testOptions)
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "payments": [${buildMockResponse()}],
@@ -142,7 +142,7 @@ describe('@freshbooks/api', () => {
 
 			const builder = new SearchQueryBuilder().equals('type', 'Cash')
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "payments": [${buildMockResponse()}],

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -192,6 +192,11 @@
 				}
 			}
 		},
+		"luxon": {
+			"version": "1.25.0",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
+			"integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
+		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,10 +22,12 @@
 	"dependencies": {
 		"axios": "^0.19.2",
 		"axios-retry": "^3.1.9",
+		"luxon": "^1.25.0",
 		"winston": "^3.3.3"
 	},
 	"devDependencies": {
-		"axios-mock-adapter": "^1.17.0"
+		"axios-mock-adapter": "^1.17.0",
+		"@types/luxon": "^1.25.1"
 	},
 	"jest": {
 		"preset": "ts-jest",

--- a/packages/api/src/models/Client.ts
+++ b/packages/api/src/models/Client.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/camelcase */
+import { transformDateResponse, DateFormat, transformDateRequest } from './Date'
 import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
-import Pagination from './Pagination'
 import { Nullable } from './helpers'
+import Pagination from './Pagination'
+import VisState from './VisState'
 
 export default interface Client {
 	id?: string
@@ -45,7 +47,7 @@ export default interface Client {
 	userId?: string
 	pStreet2?: string
 	prefGmail?: boolean
-	visState?: number
+	visState?: VisState
 	sCountry?: string
 	sStreet?: string
 	pCountry?: string
@@ -81,7 +83,7 @@ function transformClientData(client: any): Client {
 		subdomain: client.subdomain,
 		email: client.email,
 		username: client.username,
-		updated: client.updated,
+		updated: client.updated && transformDateResponse(client.updated, DateFormat['YYYY-MM-DD hh:mm:ss']),
 		pProvince: client.p_province,
 		pCity: client.p_city,
 		busPhone: client.bus_phone,
@@ -90,7 +92,7 @@ function transformClientData(client: any): Client {
 		companySize: client.company_size,
 		accountingSystemId: client.accounting_systemid,
 		pCode: client.p_code,
-		signupDate: client.signup_date,
+		signupDate: client.signup_date && transformDateResponse(client.signup_date, DateFormat['YYYY-MM-DDThh:mm:ss']), // signup_date returns in UTC
 		language: client.language,
 		level: client.level,
 		notified: client.notified,
@@ -184,7 +186,6 @@ export function transformClientRequest(client: Client): string {
 			subdomain: client.subdomain,
 			email: client.email,
 			username: client.username,
-			updated: client.updated,
 			p_province: client.pProvince,
 			p_city: client.pCity,
 			bus_phone: client.busPhone,
@@ -193,7 +194,6 @@ export function transformClientRequest(client: Client): string {
 			company_size: client.companySize,
 			accounting_systemid: client.accountingSystemId,
 			p_code: client.pCode,
-			signup_date: client.signupDate,
 			language: client.language,
 			level: client.level,
 			notified: client.notified,

--- a/packages/api/src/models/Client.ts
+++ b/packages/api/src/models/Client.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
+import { DateTime } from 'luxon'
 import { transformDateResponse, DateFormat, transformDateRequest } from './Date'
 import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
 import { Nullable } from './helpers'
@@ -92,7 +93,7 @@ function transformClientData(client: any): Client {
 		companySize: client.company_size,
 		accountingSystemId: client.accounting_systemid,
 		pCode: client.p_code,
-		signupDate: client.signup_date && transformDateResponse(client.signup_date, DateFormat['YYYY-MM-DDThh:mm:ss']), // signup_date returns in UTC
+		signupDate: client.signup_date && DateTime.fromSQL(client.signup_date, { zone: 'UTC' }).toJSDate(), // signup date is in UTC
 		language: client.language,
 		level: client.level,
 		notified: client.notified,

--- a/packages/api/src/models/Date.ts
+++ b/packages/api/src/models/Date.ts
@@ -14,7 +14,7 @@ export const transformDateRequest = (date: Date): string => {
 export const transformDateResponse = (dateString: string, dateFormat: DateFormat = DateFormat['YYYY-MM-DD']): Date => {
 	switch (dateFormat) {
 		case DateFormat['YYYY-MM-DD hh:mm:ss']:
-			return new Date(dateString)
+			return new Date(dateString + ' (EST)')
 		case DateFormat['YYYY-MM-DDThh:mm:ss']:
 			dateString = dateString.replace(/([^Z])$/, '$1Z') // Append Z if not present
 			return new Date(dateString)

--- a/packages/api/src/models/Date.ts
+++ b/packages/api/src/models/Date.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon'
+
 export enum DateFormat {
 	'YYYY-MM-DD' = 0,
 	'YYYY-MM-DD hh:mm:ss' = 1,
@@ -14,10 +16,10 @@ export const transformDateRequest = (date: Date): string => {
 export const transformDateResponse = (dateString: string, dateFormat: DateFormat = DateFormat['YYYY-MM-DD']): Date => {
 	switch (dateFormat) {
 		case DateFormat['YYYY-MM-DD hh:mm:ss']:
-			return new Date(dateString + ' (EST)')
+			return DateTime.fromSQL(dateString, { zone: 'America/New_York' }).toJSDate()
 		case DateFormat['YYYY-MM-DDThh:mm:ss']:
 			dateString = dateString.replace(/([^Z])$/, '$1Z') // Append Z if not present
-			return new Date(dateString)
+			return DateTime.fromISO(dateString).toJSDate()
 		default:
 			return new Date(`${dateString} 00:00:00`)
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,6 +2055,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/luxon@^1.25.1":
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-1.25.1.tgz#9f33aead0c7fdb86434059410c7a712517d97cd8"
+  integrity sha512-enkMO4WJcbdkhK1eZrItF616buau02wtrSN+DDt9Qj9U23boSAXNJm0fMlgwpTDaRHq3S0D/SPIRbxy4YxBjiA==
+
 "@types/mime@*":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"
@@ -6350,6 +6355,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+luxon@^1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.25.0.tgz#d86219e90bc0102c0eb299d65b2f5e95efe1fe72"
+  integrity sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ==
 
 macos-release@^2.2.0:
   version "2.4.1"


### PR DESCRIPTION
# Purpose

Fix Client Model
- visState should us the VisState.ts enum (currently a string)
- updated and signupDate should be parsed as dates (currently strings)
- updated some tests to better test UTC dates

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/37
<!-- Please do not reference internal bug trackers as this is a public project -->