### PR TITLE
Refs SLAPI-197 Added check for null account_id in business segment 

### DIFF
--- a/packages/api/__tests__/Business.test.ts
+++ b/packages/api/__tests__/Business.test.ts
@@ -131,5 +131,70 @@ describe('@freshbooks/api', () => {
 				})
 			)
 		})
+
+		test('Verify parsed JSON -> model transform', async () => {
+			const json = `{
+                "id": 77128,
+                "name": "BillSpring",
+                "account_id": null,
+                "address": {
+                    "id": 74595,
+                    "street": "123",
+                    "city": "Toronto",
+                    "province": "Ontario",
+                    "country": "Canada",
+                    "postal_code": "A1B2C3"
+                },
+                "phone_number": null,
+                "business_clients": [
+                    {
+                        "id": 22347,
+                        "business_id": 77128,
+                        "account_id": "Xr82w",
+                        "userid": 74353,
+                        "client_business": {
+                            "business_id": 77128
+                        },
+                        "account_business": {
+                            "account_business_id": 363103,
+                            "account_id": "Xr82w"
+                        }
+                    }
+                ]
+            }`
+			const model = transformBusinessJSON(json)
+
+			expect(model).toEqual(
+				expect.objectContaining({
+					id: '77128',
+					name: 'BillSpring',
+					accountId: '',
+					address: {
+						id: '74595',
+						street: '123',
+						city: 'Toronto',
+						province: 'Ontario',
+						country: 'Canada',
+						postalCode: 'A1B2C3',
+					},
+					phoneNumber: null,
+					businessClients: [
+						{
+							id: '22347',
+							businessId: '77128',
+							accountId: 'Xr82w',
+							userId: '74353',
+							clientBusiness: {
+								businessId: '77128',
+							},
+							accountBusiness: {
+								businessId: '363103',
+								accountId: 'Xr82w',
+							},
+						},
+					],
+				})
+			)
+		})
 	})
 })

--- a/packages/api/src/models/Business.ts
+++ b/packages/api/src/models/Business.ts
@@ -67,7 +67,7 @@ export function transformBusinessResponse({
 	return {
 		id: id.toString(),
 		name,
-		accountId: accountId.toString(),
+		accountId: accountId !== null ? accountId.toString() : '',
 		address: transformAddressResponse(address),
 		phoneNumber: phone_number !== null ? transformPhoneNumberResponse(phone_number) : null,
 		businessClients: business_clients.map(transformBusinessClientResponse),


### PR DESCRIPTION
# Purpose

Currently, we have a case where the "me" endpoint returns null for an account_id. This causes an issue when an attempt is made to parse that to a string. 

