### PR TITLE
🐛 Fix me() call for partially setup business

### DIFF
--- a/packages/api/__tests__/BusinessMembership.test.ts
+++ b/packages/api/__tests__/BusinessMembership.test.ts
@@ -75,6 +75,36 @@ describe('@freshbooks/api', () => {
 				})
 			)
 		})
+		test('Verify JSON -> model transform -- partially setup account', async () => {
+			const json = `{
+                "id": 168372,
+                "role": "owner",
+                "business": {
+                    "id": 77128,
+                    "name": null,
+                    "account_id": "zDmNq",
+                    "address": null,
+                    "phone_number": null,
+                    "business_clients": []
+                }
+            }`
+			const model = transformBusinessMembershipJSON(json)
+
+			expect(model).toEqual(
+				expect.objectContaining({
+					id: '168372',
+					role: 'owner',
+					business: {
+						id: '77128',
+						name: null,
+						accountId: 'zDmNq',
+						address: null,
+						phoneNumber: null,
+						businessClients: [],
+					},
+				})
+			)
+		})
 		test('Verify parsed JSON -> model transform', async () => {
 			const data = {
 				id: 168372,

--- a/packages/api/src/models/Business.ts
+++ b/packages/api/src/models/Business.ts
@@ -8,7 +8,7 @@ export default interface Business {
 	id: string
 	name: string
 	accountId: string
-	address: Address
+	address: Nullable<Address>
 	phoneNumber?: Nullable<PhoneNumber>
 	businessClients: BusinessClient[]
 }
@@ -68,7 +68,7 @@ export function transformBusinessResponse({
 		id: id.toString(),
 		name,
 		accountId: accountId !== null ? accountId.toString() : '',
-		address: transformAddressResponse(address),
+		address: address !== null ? transformAddressResponse(address) : null,
 		phoneNumber: phone_number !== null ? transformPhoneNumberResponse(phone_number) : null,
 		businessClients: business_clients.map(transformBusinessClientResponse),
 	}


### PR DESCRIPTION
# Purpose

If the user doesn't complete setup, the users.me() calls fail when fetching from the /me endpoint as the business address is empty.

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/54
<!-- Please do not reference internal bug trackers as this is a public project -->