### PR TITLE
Fix object keyname that violates conding convention

### DIFF
--- a/packages/api/__tests__/OtherIncome.test.ts
+++ b/packages/api/__tests__/OtherIncome.test.ts
@@ -123,7 +123,7 @@ describe('@freshbooks/api', () => {
 			mock.onGet(`/accounting/account/${ACCOUNT_ID}/other_incomes/other_incomes`).replyOnce(200, mockResponse)
 
 			const expected = {
-				other_income: [buildOtherIncome()],
+				otherIncomes: [buildOtherIncome()],
 				pages: {
 					page: 1,
 					pages: 1,
@@ -159,7 +159,7 @@ describe('@freshbooks/api', () => {
 				.replyOnce(200, mockResponse)
 
 			const expected = {
-				other_income: [buildOtherIncome()],
+				otherIncomes: [buildOtherIncome()],
 				pages: {
 					page: 1,
 					pages: 1,

--- a/packages/api/__tests__/TimeEntry.test.ts
+++ b/packages/api/__tests__/TimeEntry.test.ts
@@ -80,7 +80,7 @@ describe('@freshbooks/api', () => {
 		    ]
 		    }`
 			const expected = {
-				time_entries: [buildExpectedTimeEntryResult()],
+				timeEntries: [buildExpectedTimeEntryResult()],
 				pages: {
 					page: 1,
 					pages: 1,

--- a/packages/api/src/models/OtherIncome.ts
+++ b/packages/api/src/models/OtherIncome.ts
@@ -62,7 +62,7 @@ function transformOtherIncomeData({
 
 export function transformListOtherIncomesResponse(
 	data: string
-): { other_income: OtherIncome[]; pages: Pagination } | ErrorResponse {
+): { otherIncomes: OtherIncome[]; pages: Pagination } | ErrorResponse {
 	const response = JSON.parse(data)
 
 	if (isAccountingErrorResponse(response)) {
@@ -71,7 +71,7 @@ export function transformListOtherIncomesResponse(
 
 	const { other_income, per_page, total, page, pages } = response.response.result
 	return {
-		other_income: other_income.map((otherIncome: any) => transformOtherIncomeData(otherIncome)),
+		otherIncomes: other_income.map((otherIncome: any) => transformOtherIncomeData(otherIncome)),
 		pages: {
 			page,
 			pages,

--- a/packages/api/src/models/TimeEntry.ts
+++ b/packages/api/src/models/TimeEntry.ts
@@ -75,7 +75,7 @@ export function transformTimeEntryResponse(data: any): TimeEntry | ErrorResponse
  */
 export function transformTimeEntryListResponse(
 	data: string
-): { time_entries: TimeEntry[]; pages: Pagination } | ErrorResponse {
+): { timeEntries: TimeEntry[]; pages: Pagination } | ErrorResponse {
 	const response = JSON.parse(data)
 
 	if (isProjectErrorResponse(response)) {
@@ -90,7 +90,7 @@ export function transformTimeEntryListResponse(
 			size: per_page,
 			total,
 		},
-		time_entries: time_entries.map((time_entry: TimeEntry) => transformTimeEntryData(time_entry)),
+		timeEntries: time_entries.map((time_entry: TimeEntry) => transformTimeEntryData(time_entry)),
 	}
 }
 


### PR DESCRIPTION
# Purpose
This PR updates the snake case(snake_case) to the camel case in the key name of the return object in otherIncome and timeEntry list method.

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/57