### PR TITLE
👽 Update error handling for typescript

### DIFF
--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -146,7 +146,7 @@ export default class APIClient {
 				ok: true,
 				data: response.data,
 			}
-		} catch (err) {
+		} catch (err: any) {
 			if (err.response) {
 				const {
 					response: { status, statusText, data: errData },

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -17,7 +17,7 @@ const defaultVerifyFn = (clientId: string) => {
 				}
 				done(null, user)
 			}
-		} catch (err) {
+		} catch (err: any) {
 			done(err)
 		}
 	}


### PR DESCRIPTION
# Purpose

dependabot recently failed to upgrade to typescript 4.4, looks like this is the issue. See https://stackoverflow.com/questions/68240884/error-object-inside-catch-is-of-type-unkown
