### PR TITLE
👽 Update error handling for typescript

### DIFF
--- a/packages/api/__tests__/APIClient.test.ts
+++ b/packages/api/__tests__/APIClient.test.ts
@@ -16,8 +16,8 @@ describe('@freshbooks/api', () => {
 		test('Test user agent throws error when clientId not set', () => {
 			const token = 'test-token'
 			try {
-				const client: APIClient = new APIClient(token)
-			} catch (err) {
+				new APIClient(token)
+			} catch (err: any) {
 				expect(err.name).toEqual('missing clientId')
 				expect(err.message).toEqual('missing clientId')
 			}
@@ -41,7 +41,7 @@ describe('@freshbooks/api', () => {
 			const client = new APIClient('foo', testOptions)
 			try {
 				await client.users.me()
-			} catch (err) {
+			} catch (err: any) {
 				expect(err.code).toEqual('unauthenticated')
 				expect(err.message).toEqual('This action requires authentication to continue.')
 			}
@@ -63,7 +63,7 @@ describe('@freshbooks/api', () => {
 			const client = new APIClient('foo', testOptions)
 			try {
 				await client.invoices.list('zDmNq')
-			} catch (error) {
+			} catch (error: any) {
 				expect(error.name).toEqual('List Invoices')
 				expect(error.code).toEqual('401')
 				expect(error.errors).toEqual([
@@ -86,7 +86,7 @@ describe('@freshbooks/api', () => {
 			const client = new APIClient('foo', testOptions)
 			try {
 				await client.invoices.single('zDmNq', '1')
-			} catch (error) {
+			} catch (error: any) {
 				expect(error.code).toEqual('not_found')
 				expect(error.message).toEqual('The requested resource was not found.')
 			}
@@ -115,8 +115,8 @@ describe('@freshbooks/api', () => {
 				.onGet('/auth/api/v1/users/me')
 				.replyOnce(
 					200,
-					`{ 
-					"response":{ 
+					`{
+					"response":{
 					   "id":2192788}}`
 				)
 

--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -146,7 +146,7 @@ export default class APIClient {
 				ok: true,
 				data: response.data,
 			}
-		} catch (err) {
+		} catch (err: any) {
 			if (err.response) {
 				const {
 					response: { status, statusText, data: errData },

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -17,7 +17,7 @@ const defaultVerifyFn = (clientId: string) => {
 				}
 				done(null, user)
 			}
-		} catch (err) {
+		} catch (err: any) {
 			done(err)
 		}
 	}


### PR DESCRIPTION
# Purpose

dependabot recently failed to upgrade to typescript 4.4, looks like this is the issue. See https://stackoverflow.com/questions/68240884/error-object-inside-catch-is-of-type-unkown
