### PR TITLE
♻️ Standardize application client id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Unreleased
 
+- (**Breaking Change**) FreshBooks application clientId added to APIClient
+  constructor instead of optional (but not actually optional) param
 - (**Breaking Change**) Fix types on data models
 - (**Breaking Change**) Rename models to better fit coding conventions
 - Support Bills, Bill Payments, Bill Vendors endpoints
@@ -45,6 +47,10 @@
 - Added default retries with backoff on failed API calls
 
 ## @freshbooks/app
+
+### Unreleased
+
+- (**Breaking Change**) Updated to latest breaking api changes.
 
 ### 1.0.6
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ const clientId = process.env.FRESHBOOKS_APPLICATION_CLIENTID
 const token = process.env.FRESHBOOKS_TOKEN
 
 // Instantiate new FreshBooks API client
-const client = new Client(token, {
-    clientId: FRESHBOOKS_APPLICATION_CLIENTID
-});
+const client = new Client(clientId, token);
 ```
 
 #### Get/set data from REST API
@@ -226,7 +224,7 @@ app.get('/auth/freshbooks/redirect', passport.authorize('freshbooks'))
 app.get('/settings', passport.authorize('freshbooks'), async (req, res) => {
   // get an API client
   const { token } = req.user
-  const client = new Client(token)
+  const client = new Client(CLIENT_ID, token)
 
   // fetch the current user
   try {

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -41,9 +41,7 @@ const clientId = process.env.FRESHBOOKS_APPLICATION_CLIENTID
 const token = process.env.FRESHBOOKS_TOKEN
 
 // Instantiate new FreshBooks API client
-const client = new Client(token, {
-    clientId: FRESHBOOKS_APPLICATION_CLIENTID
-});
+const client = new Client(clientId, token);
 ```
 
 #### Get/set data from REST API

--- a/packages/api/__tests__/APIClient.test.ts
+++ b/packages/api/__tests__/APIClient.test.ts
@@ -3,29 +3,20 @@ import MockAdapter from 'axios-mock-adapter'
 import APIClient, { Options } from '../src/APIClient'
 
 const mock = new MockAdapter(axios) // set mock adapter on default axios instance
-const testOptions: Options = { clientId: 'test-client-id' }
+const clientId = 'test-client-id'
+const testOptions: Options = {}
 
 describe('@freshbooks/api', () => {
 	describe('Client', () => {
 		test('Default init', () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(clientId, token, testOptions)
 			expect(client).not.toBeNull()
-		})
-
-		test('Test user agent throws error when clientId not set', () => {
-			const token = 'test-token'
-			try {
-				new APIClient(token)
-			} catch (err: any) {
-				expect(err.name).toEqual('missing clientId')
-				expect(err.message).toEqual('missing clientId')
-			}
 		})
 
 		test('Test user agent when set returns correct value', () => {
 			const token = 'test-token'
-			const client: APIClient = new APIClient(token, testOptions)
+			const client: APIClient = new APIClient(clientId, token, testOptions)
 
 			expect(client.clientId).toEqual('test-client-id')
 		})
@@ -38,7 +29,7 @@ describe('@freshbooks/api', () => {
 					'{"error":"unauthenticated","error_description":"This action requires authentication to continue."}'
 				)
 
-			const client = new APIClient('foo', testOptions)
+			const client = new APIClient(clientId, 'foo', testOptions)
 			try {
 				await client.users.me()
 			} catch (err: any) {
@@ -60,7 +51,7 @@ describe('@freshbooks/api', () => {
 			})
 			mock.onGet('/accounting/account/zDmNq/invoices/invoices').replyOnce(401, mockResponse)
 
-			const client = new APIClient('foo', testOptions)
+			const client = new APIClient(clientId, 'foo', testOptions)
 			try {
 				await client.invoices.list('zDmNq')
 			} catch (error: any) {
@@ -83,7 +74,7 @@ describe('@freshbooks/api', () => {
 			})
 			mock.onGet('/accounting/account/zDmNq/invoices/invoices/1').replyOnce(401, mockResponse)
 
-			const client = new APIClient('foo', testOptions)
+			const client = new APIClient(clientId, 'foo', testOptions)
 			try {
 				await client.invoices.single('zDmNq', '1')
 			} catch (error: any) {
@@ -94,7 +85,7 @@ describe('@freshbooks/api', () => {
 
 		test('Test unhandled errors', async () => {
 			const unhandledError = new Error('Unhandled Error!')
-			const client = new APIClient('foo', testOptions)
+			const client = new APIClient(clientId, 'foo', testOptions)
 
 			// mock list method
 			client.invoices.list = jest.fn(() => {
@@ -120,7 +111,7 @@ describe('@freshbooks/api', () => {
 					   "id":2192788}}`
 				)
 
-			const client = new APIClient('foo', testOptions)
+			const client = new APIClient(clientId, 'foo', testOptions)
 			const res = await client.users.me()
 
 			expect(res.ok).toBeTruthy()
@@ -140,7 +131,7 @@ describe('@freshbooks/api', () => {
                        "id":2192788}}`
 				)
 
-			const client = new APIClient('foo', testOptions)
+			const client = new APIClient(clientId, 'foo', testOptions)
 			const res = await client.users.me()
 
 			expect(res.ok).toBeTruthy()
@@ -154,7 +145,7 @@ describe('@freshbooks/api', () => {
 				.onGet(`/accounting/account/${accountId}/invoices/invoices`)
 				.replyOnce(200, '{"response":{"result":{"invoices": [],"page": 1,"pages": 1,"per_page": 15,"total": 7}}}')
 
-			const client = new APIClient('foo', testOptions)
+			const client = new APIClient(clientId, 'foo', testOptions)
 			const res = await client.invoices.list('xZNQ1X')
 			expect(res.ok).toBeTruthy()
 			expect(res.data).not.toBeUndefined()

--- a/packages/api/__tests__/BillPayments.test.ts
+++ b/packages/api/__tests__/BillPayments.test.ts
@@ -13,9 +13,10 @@ enum PaymentType {
 }
 
 const mock = new MockAdapter(axios)
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 const token = 'token'
-const client = new APIClient(token, testOptions)
+const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 const ACCOUNT_ID = 'zDmNq'
 const BILL_PAYMENT_ID = 122334455
 const BILL_ID = 43221133

--- a/packages/api/__tests__/BillVendors.test.ts
+++ b/packages/api/__tests__/BillVendors.test.ts
@@ -5,7 +5,8 @@ import APIClient, { Options } from '../src/APIClient'
 import { BillVendors } from '../src/models'
 
 const mock = new MockAdapter(axios) // set mock adapter on default axios instance
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 const ACCOUNT_ID = 'zDmNq'
 const VENDOR_ID = 1563
@@ -98,7 +99,7 @@ describe('@freshbooks/api', () => {
 	describe('BillVendors', () => {
 		test('GET /accounting/account/<account_id>/bill_vendors/bill_vendors list', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `
                 {"response":
@@ -131,7 +132,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('GET /accounting/account/<account_id>/bill_vendors/bill_vendors/<vendor_id>', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `
             {"response":
@@ -152,7 +153,7 @@ describe('@freshbooks/api', () => {
 
 		test('POST /accounting/account/<accountId>/bill_vendors/bill_vendors create', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 			const mockResponse = `
             {"response":
                 {
@@ -173,7 +174,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('PUT /accounting/account/<accountId>/bill_vendors/bill_vendors/<vendorId> update', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `
             {"response":
@@ -197,7 +198,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('PUT /accounting/account/<accountId>/bill_vendors/bill_vendors/<vendorId> delete', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `
             {"response":

--- a/packages/api/__tests__/Bills.test.ts
+++ b/packages/api/__tests__/Bills.test.ts
@@ -7,9 +7,10 @@ import { joinQueries } from '../src/models/builders'
 import { SearchQueryBuilder } from '../src/models/builders/SearchQueryBuilder'
 
 const mock = new MockAdapter(axios)
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 const token = 'token'
-const client = new APIClient(token, testOptions)
+const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 const ACCOUNT_ID = 'zDmNq'
 const BILL_ID = 43221133

--- a/packages/api/__tests__/Client.test.ts
+++ b/packages/api/__tests__/Client.test.ts
@@ -11,7 +11,8 @@ const mock = new MockAdapter(axios) // set mock adapter on default axios instanc
 
 const ACCOUNT_ID = 'xZNQ1X'
 const CLIENT_ID = '218192'
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 const buildClientResponse = (clientResponseProperties: any = {}): any => ({
 	accounting_systemid: ACCOUNT_ID,
@@ -132,7 +133,7 @@ describe('@freshbooks/api', () => {
 	describe('Client', () => {
 		test('GET /accounting/account/<accountId>/users/clients?...searchQuery', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 			const response = `
 		  {
 		    "response": {
@@ -166,7 +167,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('GET /accounting/account/<accountId>/users/clients', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 			const response = `
       {
         "response": {
@@ -200,7 +201,7 @@ describe('@freshbooks/api', () => {
 
 		test('GET /accounting/account/<accountId>/users/clients/<clientId>', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = buildMockClientJSONResponse()
 			mock.onGet(`/accounting/account/${ACCOUNT_ID}/users/clients/${CLIENT_ID}`).replyOnce(200, mockResponse)
@@ -214,7 +215,7 @@ describe('@freshbooks/api', () => {
 
 		test('POST /accounting/account/<accountId>/users/clients', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const clientModel = {
 				fName: 'Johnny',
@@ -249,7 +250,7 @@ describe('@freshbooks/api', () => {
 	})
 	test('PUT /accounting/account/<accountId>/users/clients/<clientId> (delete)', async () => {
 		const token = 'token'
-		const APIclient = new APIClient(token, testOptions)
+		const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 		const mockResponse = buildMockClientJSONResponse({ vis_state: 1 })
 
@@ -269,7 +270,7 @@ describe('@freshbooks/api', () => {
 
 	test('PUT /accounting/account/<accountId>/users/clients/<clientId>', async () => {
 		const token = 'token'
-		const APIclient = new APIClient(token, testOptions)
+		const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 		const mockResponse = buildMockClientJSONResponse()
 

--- a/packages/api/__tests__/Expense.test.ts
+++ b/packages/api/__tests__/Expense.test.ts
@@ -11,6 +11,7 @@ const mock = new MockAdapter(axios) // set mock adapter on default axios instanc
 
 const ACCOUNT_ID = 'zDmNq'
 const EXPENSE_ID = '43221133'
+const APPLICATION_CLIENT_ID = 'test-client-id'
 
 const buildMockResponse = (expenseProperties: any = {}): string =>
 	JSON.stringify({
@@ -128,13 +129,13 @@ const buildMockRequest = (expenseProperties: any = {}): any => ({
 	},
 })
 
-const testOptions: Options = { clientId: 'test-client-id' }
+const testOptions: Options = {}
 
 describe('@freshbooks/api', () => {
 	describe('Expense', () => {
 		test('GET /accounting/account/<accountid>/expenses/expenses/<id>', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `{
 					"response":{
@@ -154,7 +155,7 @@ describe('@freshbooks/api', () => {
 
 		test('GET /accounting/account/<accountid>/expenses/expenses', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `{
 					"response":{
@@ -186,7 +187,7 @@ describe('@freshbooks/api', () => {
 
 		test('GET /accounting/account/<accountid>/expenses/expenses?include[]=category', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const category = {
 				category: 'Accident Insurance',
@@ -235,7 +236,7 @@ describe('@freshbooks/api', () => {
 
 		test(`GET /accounting/account/<accountid>/expenses/expenses/search[expenseid]=${EXPENSE_ID}`, async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `{
 					"response":{
@@ -271,7 +272,7 @@ describe('@freshbooks/api', () => {
 
 		test('POST /accounting/account/<accountid>/expenses/expenses', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `{
 					"response":{
@@ -293,7 +294,7 @@ describe('@freshbooks/api', () => {
 
 		test('PUT /accounting/account/<accountid>/expenses/expenses/<expenseid>', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `{
 					"response":{
@@ -317,7 +318,7 @@ describe('@freshbooks/api', () => {
 
 		test('PUT /accounting/account/<accountid>/expenses/expenses/<expenseid> (delete)', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `
             {"response":

--- a/packages/api/__tests__/Invoice.test.ts
+++ b/packages/api/__tests__/Invoice.test.ts
@@ -8,7 +8,8 @@ import { SearchQueryBuilder } from '../src/models/builders/SearchQueryBuilder'
 
 const mock = new MockAdapter(axios) // set mock adapter on default axios instance
 const ACCOUNT_ID = 'xZNQ1X'
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 const buildMockResponse = (invoiceProperties: any = {}): string => {
 	return JSON.stringify({
@@ -217,7 +218,7 @@ describe('@freshbooks/api', () => {
 	describe('Invoice', () => {
 		test('GET /accounting/account/<accountId>/invoices/invoices/<invoiceId>', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 			const INVOICE_ID = '217506'
 
 			const mockResponse = `
@@ -237,7 +238,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('GET /accounting/account/<accountId>/invoices/invoices', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `
                 {"response":
@@ -270,7 +271,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('GET /accounting/account/<accountId>/invoices/invoices?include[]=lines', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `
                 {"response":
@@ -370,7 +371,7 @@ describe('@freshbooks/api', () => {
 
 		test('GET /accounting/account/<accountId>/invoices/invoices?search[invoice_id]=217506', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `
                 {"response":
@@ -404,7 +405,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('POST /accounting/account/<accountId>/invoices/invoices', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 			const mockResponse = `
             {"response":
                 {
@@ -422,7 +423,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('PUT /accounting/account/<accountId>/invoices/invoices/<invoiceId>', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 			const INVOICE_ID = '217506'
 
 			const mockResponse = `
@@ -445,7 +446,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('PUT /accounting/account/<accountId>/invoices/invoices/<invoiceId> (delete)', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 			const INVOICE_ID = '217506'
 
 			const mockResponse = `

--- a/packages/api/__tests__/Item.test.ts
+++ b/packages/api/__tests__/Item.test.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
-import APIClient, { Options } from '../src/APIClient'
+import APIClient from '../src/APIClient'
 import Item from '../src/models/Item'
 
 const mock = new MockAdapter(axios) // set mock adapter on default axios instance
 
 const ACCOUNT_ID = 'zDmNq'
 const ITEM_ID = '201225'
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
 
 const buildMockResponse = (itemProperties: any = {}): string =>
 	JSON.stringify({
@@ -73,9 +73,9 @@ describe('@freshbooks/api', () => {
 	describe('Item', () => {
 		test('GET /accounting/account/<accountid>/items/items/<id>', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token)
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "item": ${buildMockResponse()}
@@ -93,9 +93,9 @@ describe('@freshbooks/api', () => {
 		})
 		test('GET /accounting/account/<accountid>/items/items', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token)
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
 							"items": [${buildMockResponse()}],
@@ -125,9 +125,9 @@ describe('@freshbooks/api', () => {
 		})
 		test('PUT /accounting/account/<accountid>/items/items/<id>', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token)
 
-			const mockResponse = `{ 
+			const mockResponse = `{
 					"response":{
                         "result": {
                             "item": ${buildMockResponse({ qty: '10' })}
@@ -149,7 +149,7 @@ describe('@freshbooks/api', () => {
 
 		test('PUT /accounting/account/<accountid>/items/items/<id> (delete)', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token)
 
 			const mockResponse = `{
 					"response":{
@@ -171,7 +171,7 @@ describe('@freshbooks/api', () => {
 
 		test('POST /accounting/account/<accountid>/items/items', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token)
 
 			const mockResponse = `{
 					"response":{

--- a/packages/api/__tests__/OtherIncome.test.ts
+++ b/packages/api/__tests__/OtherIncome.test.ts
@@ -7,7 +7,8 @@ import { SearchQueryBuilder } from '../src/models/builders/SearchQueryBuilder'
 
 const mock = new MockAdapter(axios) // set mock adapter on default axios instance
 const ACCOUNT_ID = 'xZNQ1X'
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 const buildMockResponse = (otherIncomeProperties: any = {}): string => {
 	return JSON.stringify({
@@ -82,7 +83,7 @@ describe('@freshbooks/api', () => {
 	describe('OtherIncome', () => {
 		test('GET /accounting/account/<accountId>/other_incomes/other_incomes/<otherIncomeId>', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 			const OTHER_INCOME_ID = '12345'
 
 			const mockResponse = `
@@ -104,7 +105,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('GET /accounting/account/<accountId>/other_incomes/other_incomes', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `
                 {"response":
@@ -137,7 +138,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('GET /accounting/account/<accountId>/other_incomes/other_incomes?search[incomeid]=12345', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `
                 {"response":
@@ -173,7 +174,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('POST /accounting/account/<accountId>/other_incomes/other_incomes', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 			const mockResponse = `
 		    {"response":
 		        {
@@ -194,7 +195,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('PUT /accounting/account/<accountId>/other_incomes/other_incomes/<otherIncomeId>', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 			const OTHER_INCOME_ID = '12345'
 
 			const mockResponse = `
@@ -217,7 +218,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('DELETE /accounting/account/<accountId>/other_incomes/other_incomes/<otherIncomeId>', async () => {
 			const token = 'token'
-			const client = new Client(token, testOptions)
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
 			const OTHER_INCOME_ID = '12345'
 
 			mock

--- a/packages/api/__tests__/Payment.test.ts
+++ b/packages/api/__tests__/Payment.test.ts
@@ -10,7 +10,8 @@ const mock = new MockAdapter(axios) // set mock adapter on default axios instanc
 
 const ACCOUNT_ID = 'zDmNq'
 const PAYMENT_ID = '115804'
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 const buildMockResponse = (paymentProperties: any = {}): string =>
 	JSON.stringify({
@@ -86,7 +87,7 @@ describe('@freshbooks/api', () => {
 	describe('Payment', () => {
 		test('GET /accounting/account/<accountid>/payments/payments/<paymentid>', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `{
 					"response":{
@@ -106,7 +107,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('GET /accounting/account/<accountid>/payments/payments', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = `{
 					"response":{
@@ -138,7 +139,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('GET /accounting/account/<accountid>/payments/payments?search[type]=Cash', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const builder = new SearchQueryBuilder().equals('type', 'Cash')
 
@@ -175,7 +176,7 @@ describe('@freshbooks/api', () => {
 
 		test('POST /accounting/account/<accountId>/payments/payments', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockRequest = buildMockRequest()
 			const mockResponse = `{
@@ -198,7 +199,7 @@ describe('@freshbooks/api', () => {
 
 		test('PUT /accounting/account/<accountId>/payments/payments/<paymentId>', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockRequest = buildMockRequest({}, false)
 			const mockResponse = `{
@@ -223,7 +224,7 @@ describe('@freshbooks/api', () => {
 
 		test('PUT /accounting/account/<accountId>/payments/payments/<paymentId> (delete)', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockRequest = {
 				payment: {

--- a/packages/api/__tests__/Project.test.ts
+++ b/packages/api/__tests__/Project.test.ts
@@ -8,7 +8,8 @@ const mock = new MockAdapter(axios) // set mock adapter on default axios instanc
 
 const BUSINESS_ID = 12345
 const PROJECT_ID = 218192
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 const buildProjectResponse = (projectResponseProperties: any = {}): any => ({
 	id: PROJECT_ID,
@@ -121,7 +122,7 @@ describe('@freshbooks/api', () => {
 	describe('Projects', () => {
 		test('GET /projects/business/<businessId>/projects', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 			const response = `{
 		    "meta": {
                 "total": 1,
@@ -151,7 +152,7 @@ describe('@freshbooks/api', () => {
 
 		test('GET /projects/business/<businessId>/projects/<projectId>', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = buildMockProjectJSONResponse()
 
@@ -166,7 +167,7 @@ describe('@freshbooks/api', () => {
 
 		test('POST /projects/business/<businessId>/project', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const projectModel = {
 				title: 'Some project',
@@ -192,7 +193,7 @@ describe('@freshbooks/api', () => {
 
 	test('PUT /projects/business/<businessId>/project/<projectId>', async () => {
 		const token = 'token'
-		const APIclient = new APIClient(token, testOptions)
+		const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 		const mockResponse = buildMockProjectJSONResponse({
 			title: 'Some changed project',
@@ -219,7 +220,7 @@ describe('@freshbooks/api', () => {
 
 	test('DELETE /projects/business/<businessId>/project/<projectId>', async () => {
 		const token = 'token'
-		const APIclient = new APIClient(token, testOptions)
+		const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 		mock.onDelete(`/projects/business/${BUSINESS_ID}/project/${PROJECT_ID}`).replyOnce(204, {})
 

--- a/packages/api/__tests__/Service.test.ts
+++ b/packages/api/__tests__/Service.test.ts
@@ -8,7 +8,8 @@ const mock = new MockAdapter(axios) // set mock adapter on default axios instanc
 
 const BUSINESS_ID = 12345
 const SERVICE_ID = 218192
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 const buildServiceResponse = (serviceResponseProperties: any = {}): any => ({
 	business_id: BUSINESS_ID,
@@ -43,7 +44,7 @@ describe('@freshbooks/api', () => {
 	describe('Service', () => {
 		test('GET /comments/business/<businessId>/services', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 			const response = `{
 		    "meta": {
                 "total": 1,
@@ -73,7 +74,7 @@ describe('@freshbooks/api', () => {
 
 		test('GET /comments/business/<businessId>/service/<serviceId>', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = buildMockResponse()
 
@@ -88,7 +89,7 @@ describe('@freshbooks/api', () => {
 
 		test('POST /comments/business/<businessId>/service', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockRequest = buildMockRequest()
 			const mockResponse = buildMockResponse()

--- a/packages/api/__tests__/ServiceRate.test.ts
+++ b/packages/api/__tests__/ServiceRate.test.ts
@@ -8,7 +8,8 @@ const mock = new MockAdapter(axios) // set mock adapter on default axios instanc
 
 const BUSINESS_ID = 12345
 const SERVICE_ID = 218192
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 const buildServiceRateResponse = (serviceRateResponseProperties: any = {}): any => ({
 	business_id: BUSINESS_ID,
@@ -39,7 +40,7 @@ describe('@freshbooks/api', () => {
 	describe('ServiceRate', () => {
 		test('GET /comments/business/<businessId>/service/<serviceId>/rate', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = buildMockResponse()
 
@@ -54,7 +55,7 @@ describe('@freshbooks/api', () => {
 
 		test('POST /comments/business/<businessId>/service/<serviceId>/rate', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockRequest = buildMockRequest()
 			const mockResponse = buildMockResponse()
@@ -69,7 +70,7 @@ describe('@freshbooks/api', () => {
 
 		test('PUT /comments/business/<businessId>/service/<serviceId>/rate', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockRequest = buildMockRequest()
 			const mockResponse = buildMockResponse()

--- a/packages/api/__tests__/Tasks.test.ts
+++ b/packages/api/__tests__/Tasks.test.ts
@@ -6,7 +6,8 @@ import { SearchQueryBuilder } from '../src/models/builders/SearchQueryBuilder'
 import { joinQueries } from '../src/models/builders'
 
 const mock = new MockAdapter(axios) // set mock adapter on default axios instance
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 const ACCOUNT_ID = 'zDmNq'
 const TASK_ID = 43221133
@@ -58,7 +59,7 @@ describe('@freshbooks/api', () => {
 	describe('Tasks', () => {
 		test('GET /accounting/account/<account_id>/projects/tasks list', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 			const response = `
               {
                 "response": {
@@ -92,7 +93,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('GET /accounting/account/<account_id>/projects/tasks/<task_id>', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 			const response = buildMockTasksJSONResponse()
 			const expected = buildExpectedTasksResult()
 
@@ -104,7 +105,7 @@ describe('@freshbooks/api', () => {
 
 		test('POST /accounting/account/<accountId>/projects/tasks create', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const taskModel = {
 				name: 'Walking Dogs',
@@ -140,7 +141,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('PUT /accounting/account/<accountId>/projects/tasks/<taskId> update', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = buildMockTasksJSONResponse({ description: 'Something' })
 
@@ -165,7 +166,7 @@ describe('@freshbooks/api', () => {
 		})
 		test('PUT /accounting/account/<accountId>/projects/tasks/<taskId> delete', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = buildMockTasksJSONResponse({ visState: 1 })
 

--- a/packages/api/__tests__/TimeEntry.test.ts
+++ b/packages/api/__tests__/TimeEntry.test.ts
@@ -8,7 +8,8 @@ const mock = new MockAdapter(axios) // set mock adapter on default axios instanc
 
 const BUSINESS_ID = 12345
 const TIME_ENTRY_ID = 218192
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 const buildTimeEntryResponse = (timeEntryResponseProperties: any = {}): any => ({
 	id: TIME_ENTRY_ID,
@@ -67,7 +68,7 @@ describe('@freshbooks/api', () => {
 	describe('TimeEntry', () => {
 		test('GET /timetracking/business/<businessId>/time_entries', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 			const response = `{
 		    "meta": {
                 "total": 1,
@@ -97,7 +98,7 @@ describe('@freshbooks/api', () => {
 
 		test('GET /timetracking/business/<businessId>/time_entries/<timeEntryId>', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const mockResponse = buildMockTimeEntryJSONResponse()
 
@@ -112,7 +113,7 @@ describe('@freshbooks/api', () => {
 
 		test('POST /timetracking/business/<businessId>/time_entries', async () => {
 			const token = 'token'
-			const APIclient = new APIClient(token, testOptions)
+			const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 			const timeEntryModel = {
 				clientId: 9876,
@@ -151,7 +152,7 @@ describe('@freshbooks/api', () => {
 
 	test('PUT /timetracking/business/<businessId>/time_entries/<timeEntryId>', async () => {
 		const token = 'token'
-		const APIclient = new APIClient(token, testOptions)
+		const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 		const mockResponse = buildMockTimeEntryJSONResponse({
 			started_at: '2020-01-21T10:00:00.000Z',
@@ -186,7 +187,7 @@ describe('@freshbooks/api', () => {
 
 	test('DELETE /timetracking/business/<businessId>/time_entries/<timeEntryId>', async () => {
 		const token = 'token'
-		const APIclient = new APIClient(token, testOptions)
+		const APIclient = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
 		mock.onDelete(`/timetracking/business/${BUSINESS_ID}/time_entries/${TIME_ENTRY_ID}`).replyOnce(204, {})
 

--- a/packages/api/__tests__/User.test.ts
+++ b/packages/api/__tests__/User.test.ts
@@ -3,44 +3,45 @@ import MockAdapter from 'axios-mock-adapter'
 import APIClient, { Options } from '../src/APIClient'
 
 const mock = new MockAdapter(axios) // set mock adapter on default axios instance
-const testOptions: Options = { clientId: 'test-client-id' }
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
 
 describe('@freshbooks/api', () => {
 	describe('User', () => {
 		test('GET /users/me', async () => {
 			const token = 'token'
-			const client = new APIClient(token, testOptions)
+			const client = new APIClient(APPLICATION_CLIENT_ID, token, testOptions)
 
-			const mockResponse = `{ 
-					"response":{ 
+			const mockResponse = `{
+					"response":{
 					   "id":2192788,
 					   "first_name":"Johnny",
 					   "last_name":"Appleseed",
 					   "email":"johnnyappleseed@test.com",
 					   "language":"en",
 					   "created_at":"2019-06-05T15:42:54Z",
-					   "phone_numbers":[ 
-						  { 
+					   "phone_numbers":[
+						  {
 							 "title":"",
 							 "phone_number":null
 						  }
 					   ],
-					   "addresses":[ 
+					   "addresses":[
 						  null
 					   ],
-					   "profession":{ 
+					   "profession":{
 						  "id":2609324,
 						  "business_id":2122866,
 						  "title":"Apple Consulting",
 						  "company":"Fruity Loops",
 						  "designation":null
 					   },
-					   "links":{ 
+					   "links":{
 						  "me":"/service/auth/api/v1/users?id=2192788",
 						  "roles":"/service/auth/api/v1/users/role/2192788"
 					   },
-					   "permissions":{ 
-						  "xZNQ1X":{ 
+					   "permissions":{
+						  "xZNQ1X":{
 							 "advanced_accounting.access":true,
 							 "attachments.access":true,
 							 "business_accountant.limit":10,
@@ -94,7 +95,7 @@ describe('@freshbooks/api', () => {
 							 "chase_dao.access":true,
 							 "estimate_v3_search.access":true
 						  },
-						  "3xQ74o":{ 
+						  "3xQ74o":{
 							 "advanced_accounting.access":true,
 							 "attachments.access":true,
 							 "business_accountant.limit":10,
@@ -148,8 +149,8 @@ describe('@freshbooks/api', () => {
 							 "estimate_v3_search.access":true
 						  }
 					   },
-					   "groups":[ 
-						  { 
+					   "groups":[
+						  {
 							 "id":6765686,
 							 "group_id":5206502,
 							 "role":"owner",
@@ -157,7 +158,7 @@ describe('@freshbooks/api', () => {
 							 "business_id":2122866,
 							 "active":true
 						  },
-						  { 
+						  {
 							 "id":7900914,
 							 "group_id":6157078,
 							 "role":"owner",
@@ -166,31 +167,31 @@ describe('@freshbooks/api', () => {
 							 "active":true
 						  }
 					   ],
-					   "subscription_statuses":{ 
+					   "subscription_statuses":{
 						  "xZNQ1X":"active_trial",
 						  "3xQ74o":"active_trial"
 					   },
-					   "integrations":{ 
-						  "google":{ 
+					   "integrations":{
+						  "google":{
 							 "domain":"secretmission.io",
 							 "email_address":"bhaskar@secretmission.io",
 							 "has_password":false,
 							 "is_active":true
 						  }
 					   },
-					   "business_memberships":[ 
-						  { 
+					   "business_memberships":[
+						  {
 							 "id":6765686,
 							 "role":"owner",
 							 "unacknowledged_change":false,
 							 "fasttrack_token":"eyJhbGciOiJIUzI1NiJ9.eyJmYXN0dHJhY2tfaWRlbnRpdHlfaWQiOiIyMTkyNzg4IiwiZmFzdHRyYWNrX3N5c3RlbV9pZCI6IjQzNTQ3NjQiLCJmYXN0dHJhY2tfYnVzaW5lc3NfaWQiOiIyMTIyODY2IiwiY3JlYXRlZF9hdCI6IjIwMTktMTEtMTJUMTY6NTg6MTArMDA6MDAifQ.9nfovmVa3X-iqu3ccThjtByZEGJSLujayQR8kW1rP1s",
-							 "business":{ 
+							 "business":{
 								"id":2122866,
 								"business_uuid":"046e4001-0002-616d-710a-a451d4421b13",
 								"name":"Fruity Loops",
 								"account_id":"xZNQ1X",
 								"date_format":"mm/dd/yyyy",
-								"address":{ 
+								"address":{
 								   "id":3383026,
 								   "street":"20 Fake St.",
 								   "city":"Toronto",
@@ -198,27 +199,27 @@ describe('@freshbooks/api', () => {
 								   "country":"Canada",
 								   "postal_code":"1I2K4J"
 								},
-								"phone_number":{ 
+								"phone_number":{
 								   "id":1039134,
 								   "phone_number":"5555555555"
 								},
-								"business_clients":[ 
-				 
+								"business_clients":[
+
 								]
 							 }
 						  },
-						  { 
+						  {
 							 "id":7900914,
 							 "role":"owner",
 							 "unacknowledged_change":false,
 							 "fasttrack_token":"eyJhbGciOiJIUzI1NiJ9.eyJmYXN0dHJhY2tfaWRlbnRpdHlfaWQiOiIyMTkyNzg4IiwiZmFzdHRyYWNrX3N5c3RlbV9pZCI6IjQ3MTQ3NDAiLCJmYXN0dHJhY2tfYnVzaW5lc3NfaWQiOiIyNjAzOTg4IiwiY3JlYXRlZF9hdCI6IjIwMTktMTEtMTJUMTY6NTg6MTArMDA6MDAifQ.v01c33WuVR4Zc8OtSc3epP1MNaDCuEhNZIlYlJ7ZvD4",
-							 "business":{ 
+							 "business":{
 								"id":2603988,
 								"business_uuid":"04710001-0002-ff38-0de2-a77e0c34a9a1",
 								"name":"Other business",
 								"account_id":"3xQ74o",
 								"date_format":"mm/dd/yyyy",
-								"address":{ 
+								"address":{
 								   "id":3292884,
 								   "street":null,
 								   "city":null,
@@ -227,32 +228,32 @@ describe('@freshbooks/api', () => {
 								   "postal_code":null
 								},
 								"phone_number":null,
-								"business_clients":[ 
-				 
+								"business_clients":[
+
 								]
 							 }
 						  }
 					   ],
 					   "identity_origin":"magnum",
-					   "roles":[ 
-						  { 
+					   "roles":[
+						  {
 							 "id":2290862,
 							 "role":"admin",
 							 "systemid":4354764,
 							 "userid":1,
 							 "created_at":"2019-06-05T15:42:54Z",
-							 "links":{ 
+							 "links":{
 								"destroy":"/service/auth/api/v1/users/role/2290862"
 							 },
 							 "accountid":"xZNQ1X"
 						  },
-						  { 
+						  {
 							 "id":2802256,
 							 "role":"admin",
 							 "systemid":4714740,
 							 "userid":1,
 							 "created_at":"2019-10-23T19:18:36Z",
-							 "links":{ 
+							 "links":{
 								"destroy":"/service/auth/api/v1/users/role/2802256"
 							 },
 							 "accountid":"3xQ74o"

--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -51,7 +51,11 @@ import {
 } from './models/TimeEntry'
 import { transformUserResponse } from './models/User'
 import { transformTasksListResponse, transformTasksRequest, transformTasksResponse } from './models/Tasks'
-import { transformBillVendorsRequest, transformBillVendorsResponse, transformListBillVendorsResponse } from './models/BillVendors'
+import {
+	transformBillVendorsRequest,
+	transformBillVendorsResponse,
+	transformListBillVendorsResponse,
+} from './models/BillVendors'
 import { transformBillsListResponse, transformBillsRequest, transformBillsResponse } from './models/Bills'
 import {
 	transformBillPaymentsListResponse,
@@ -96,11 +100,12 @@ export default class APIClient {
 
 	/**
 	 * FreshBooks API client
+	 * @param clientId The FreshBooks application client id
 	 * @param token Bearer token
 	 * @param options Client config options
 	 * @param logger Custom logger
 	 */
-	constructor(token: string, options?: Options, logger = _logger) {
+	constructor(clientId: string, token: string, options?: Options, logger = _logger) {
 		const defaultRetry = {
 			retries: 10,
 			retryDelay: axiosRetry.exponentialDelay, // ~100ms, 200ms, 400ms, 800ms
@@ -108,15 +113,10 @@ export default class APIClient {
 		}
 		const { apiUrl = API_URL, retryOptions = defaultRetry } = options || {}
 
+		this.clientId = clientId
 		this.token = token
 		this.apiUrl = apiUrl
 		this.logger = logger
-
-		if (!options?.clientId) {
-			throw new APIClientError('missing clientId', 'missing clientId')
-		}
-
-		this.clientId = options.clientId
 
 		let userAgent = `FreshBooks nodejs sdk/${API_VERSION} client_id ${this.clientId}`
 		if (options?.userAgent) {
@@ -972,7 +972,6 @@ export default class APIClient {
 export interface Options {
 	apiUrl?: string
 	retryOptions?: IAxiosRetryConfig
-	clientId: string
 	userAgent?: string
 }
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -48,7 +48,7 @@ app.get('/auth/freshbooks/redirect', passport.authorize('freshbooks')
 app.get('/settings', passport.authorize('freshbooks'), async (req, res) => {
   // get an API client
   const { token } = req.user
-  const client = new Client(token)
+  const client = new Client(CLIENT_ID, token)
 
   // fetch the current user
   try {

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -8,7 +8,7 @@ import FreshbooksStrategy, { SessionUser } from './PassportStrategy'
 
 const defaultVerifyFn = (clientId: string) => {
 	return async (token: string, refreshToken: string, profile: object, done: VerifyCallback): Promise<void> => {
-		const client = new Client(token, { clientId })
+		const client = new Client(clientId, token, {})
 		try {
 			const { data } = await client.users.me()
 			if (data !== null && data !== undefined) {


### PR DESCRIPTION
# Purpose

Currently to initialize the API client your need to provide the application
client_id in the optional data but this isn't actually optional as we throw
an error if it isn't provided. It would be much clearer for developers if
this was just a field of the constructor.

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/129
<!-- Please do not reference internal bug trackers as this is a public project -->