### PR TITLE
Add additional payment types

### DIFF
--- a/packages/api/src/models/BillPayments.ts
+++ b/packages/api/src/models/BillPayments.ts
@@ -9,6 +9,23 @@ enum PaymentType {
 	check = 'Check',
 	credit = 'Credit',
 	cash = 'Cash',
+	bankTransfer = 'Bank Transfer',
+	creditCard = 'Credit Card',
+	debit = 'Debit',
+	payPal = 'PayPal',
+	twoCheckout = '2Checkout',
+	visa = 'VISA',
+	mastercard = 'MASTERCARD',
+	discover = 'DISCOVER',
+	nova = 'Nova',
+	amex = 'AMEX',
+	diners = 'DINERS',
+	eurocard = 'EUROCARD',
+	jcb = 'JCB',
+	ach = 'ACH',
+	googleCheckout = "Google Checkout",
+	amazon = "Amazon",
+	other = "Other"
 }
 
 export default interface BillPayments {

--- a/packages/api/src/models/BillPayments.ts
+++ b/packages/api/src/models/BillPayments.ts
@@ -17,14 +17,10 @@ enum PaymentType {
 	visa = 'VISA',
 	mastercard = 'MASTERCARD',
 	discover = 'DISCOVER',
-	nova = 'Nova',
 	amex = 'AMEX',
 	diners = 'DINERS',
-	eurocard = 'EUROCARD',
 	jcb = 'JCB',
 	ach = 'ACH',
-	googleCheckout = "Google Checkout",
-	amazon = "Amazon",
 	other = "Other"
 }
 

--- a/packages/api/src/models/Payment.ts
+++ b/packages/api/src/models/Payment.ts
@@ -19,14 +19,10 @@ export enum PaymentType {
 	Visa = 'VISA',
 	Mastercard = 'MASTERCARD',
 	Discover = 'DISCOVER',
-	Nova = 'Nova',
 	Amex = 'AMEX',
 	Diners = 'DINERS',
-	Eurocard = 'EUROCARD',
 	Jcb = 'JCB',
 	Ach = 'ACH',
-	GoogleCheckout = "Google Checkout",
-	Amazon = "Amazon",
 	Other = "Other"
 }
 

--- a/packages/api/src/models/Payment.ts
+++ b/packages/api/src/models/Payment.ts
@@ -11,6 +11,20 @@ export enum PaymentType {
 	Check = 'Check',
 	Credit = 'Credit',
 	Cash = 'Cash',
+	BankTransfer = 'Bank Transfer',
+	CreditCard = 'Credit Card',
+	Debit = 'Debit',
+	PayPal = 'PayPal',
+	TwoCheckout = '2Checkout',
+	Visa = 'VISA',
+	Mastercard = 'MASTERCARD',
+	Discover = 'DISCOVER',
+	Nova = 'Nova',
+	Amex = 'AMEX',
+	Diners = 'DINERS',
+	Eurocard = 'EUROCARD',
+	Jcb = 'JCB',
+	Ach = 'ACH',
 }
 
 export default interface Payment {

--- a/packages/api/src/models/Payment.ts
+++ b/packages/api/src/models/Payment.ts
@@ -25,6 +25,9 @@ export enum PaymentType {
 	Eurocard = 'EUROCARD',
 	Jcb = 'JCB',
 	Ach = 'ACH',
+	GoogleCheckout = "Google Checkout",
+	Amazon = "Amazon",
+	Other = "Other"
 }
 
 export default interface Payment {


### PR DESCRIPTION
# Purpose

We have multiple payment types that we support on the API - that are not present in the SDK this PR adds the missing payment types. 

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/105