### PR TITLE
Calls are broken

### DIFF
--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -152,6 +152,13 @@ export default class APIClient {
 		name?: string
 	): Promise<Result<T>> {
 		try {
+			if (this.axios.defaults.headers) {
+				if (method === 'GET') {
+					delete this.axios.defaults.headers['Content-Type']
+				} else {
+					this.axios.defaults.headers['Content-Type'] = 'application/json'
+				}
+			}
 			const response = await this.axios({
 				method,
 				url,


### PR DESCRIPTION
# Purpose

Since axios 0.21.4 if you have 'Content-Type' on the header and pass data even if is null the axios will try to stringify this to 'null' and send with your request even if this is a 'GET' request which causes a _Your client has issued a malformed or illegal request._

So the call method it's been modified to handle with the 'Content-Type' in the header if the method is 'GET'

#### Related Material
[Axios 0.21.4](https://github.com/axios/axios/pull/4020/files)