### PR TITLE
🐛 Allow create/update payloads items to accept strings in addition to date objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Unreleased
 
+- Allow create/update payloads items to accept strings in addition to date objects
+
 ### 2.0.1
 
 - Fix to axios upgrade that broke GET calls

--- a/packages/api/src/models/Date.ts
+++ b/packages/api/src/models/Date.ts
@@ -7,6 +7,9 @@ export enum DateFormat {
 }
 
 export const transformDateRequest = (date: Date): string => {
+	if (typeof date === 'string') {
+		date = new Date(date);
+	}
 	const year = date.getFullYear()
 	const month = date.toLocaleDateString(undefined, { month: '2-digit' })
 	const day = date.toLocaleDateString(undefined, { day: '2-digit' })


### PR DESCRIPTION
# Purpose

Currently this fails:

```javascript
const payload = {
	amount: {
		amount: '5',
		code: 'CAD',
	},
	date: '2020-08-16',
	categoryName: 'in_person_sales',
	note: 'some',
	source: 'Some sale',
	taxes: [],
}
```

But will succeed with `date: new Date('2020-08-16'),`.

This change will allow both.

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/148
<!-- Please do not reference internal bug trackers as this is a public project -->