### PR TITLE
✨ Support webhook callback endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Unreleased
 
 - Support for invoice share links
+- Support for webhook callback registration
 - Allow create/update payloads items to accept strings in addition to date objects
 
 ### 2.0.1

--- a/packages/api/__tests__/Callback.test.ts
+++ b/packages/api/__tests__/Callback.test.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import Client, { Options } from '../src/APIClient'
+import { Callback } from '../src/models'
+
+const mock = new MockAdapter(axios) // set mock adapter on default axios instance
+const ACCOUNT_ID = 'xZNQ1X'
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = {}
+
+const buildMockResponse = (resourceId: string): string => {
+	return JSON.stringify({
+		'callbackid': Number(resourceId),
+        'event': 'invoice.create',
+        'uri': 'http://goolge.com',
+        'verified': true,
+    	'updated_at': '2021-10-17 05:48:42',
+	})
+}
+
+const buildCallback = (): Callback => ({
+	callbackId: 80001,
+	event: 'invoice.create',
+	uri: 'http://goolge.com',
+	verified: true,
+	updatedAt: new Date('2021-10-17 09:48:42Z'),
+})
+
+describe('@freshbooks/api', () => {
+	describe('Callbacks', () => {
+		test('GET Callback single', async () => {
+			const token = 'token'
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
+			const CALLBACK_ID = '80001'
+
+			const mockResponse = `
+            {"response":
+                {
+                    "result": {
+                        "callback": ${buildMockResponse(CALLBACK_ID)}
+                    }
+                }
+            }`
+			mock.onGet(`/events/account/${ACCOUNT_ID}/events/callbacks/${CALLBACK_ID}`).replyOnce(200, mockResponse)
+
+			const expected = buildCallback()
+			const { data } = await client.callbacks.single(ACCOUNT_ID, CALLBACK_ID)
+
+			expect(data).toEqual(expected)
+		})
+
+		test('PUT Callback Verification', async () => {
+			const token = 'token'
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
+			const CALLBACK_ID = '80001'
+			const VERIFIER = 'some_verifier'
+
+			const mockResponse = `
+            {"response":
+                {
+                    "result": {
+                        "callback": ${buildMockResponse(CALLBACK_ID)}
+                    }
+                }
+            }`
+
+			const mockRequest = {
+                "callback": {
+					"verifier": VERIFIER
+				}
+            }
+			mock.onPut(`/events/account/${ACCOUNT_ID}/events/callbacks/${CALLBACK_ID}`, mockRequest).replyOnce(200, mockResponse)
+
+			await client.callbacks.verify(ACCOUNT_ID, CALLBACK_ID, VERIFIER)
+		})
+
+		test('PUT Callback Resend Verification', async () => {
+			const token = 'token'
+			const client = new Client(APPLICATION_CLIENT_ID, token, testOptions)
+			const CALLBACK_ID = '80001'
+
+			const mockResponse = `
+            {"response":
+                {
+                    "result": {
+                        "callback": ${buildMockResponse(CALLBACK_ID)}
+                    }
+                }
+            }`
+
+			const mockRequest = {
+                "callback": {
+					"resend": true
+				}
+            }
+			mock.onPut(`/events/account/${ACCOUNT_ID}/events/callbacks/${CALLBACK_ID}`, mockRequest).replyOnce(200, mockResponse)
+
+			await client.callbacks.resendVerification(ACCOUNT_ID, CALLBACK_ID)
+		})
+	})
+})

--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -24,6 +24,7 @@ import {
 	User,
 	BillVendors,
 	CreditNote,
+	Callback,
 } from './models'
 import { transformClientResponse, transformClientListResponse, transformClientRequest } from './models/Client'
 import { transformListInvoicesResponse, transformInvoiceResponse, transformInvoiceRequest } from './models/Invoices'
@@ -69,6 +70,13 @@ import {
 	transformCreditNoteResponse,
 	transformCreditNoteRequest,
 } from './models/CreditNote'
+import {
+	transformCallbackListResponse,
+	transformCallbackResponse,
+	transformCallbackRequest,
+	transformCallbackVerifierRequest,
+	transformCallbackResendRequest,
+} from './models/Callback'
 
 // defaults
 const API_URL = 'https://api.freshbooks.com'
@@ -1049,6 +1057,83 @@ export default class APIClient {
 					visState: 1,
 				},
 				'Delete Credit Note'
+			),
+	}
+	public readonly callbacks = {
+		list: (
+			accountId: string,
+			queryBuilders?: QueryBuilderType[]
+		): Promise<Result<{ callbacks: Callback[]; pages: Pagination }>> =>
+			this.call(
+				'GET',
+				`/events/account/${accountId}/events/callbacks${joinQueries(queryBuilders)}`,
+				{
+					transformResponse: transformCallbackListResponse,
+				},
+				null,
+				'List Callback'
+			),
+		single: (accountId: string, callbackId: string): Promise<Result<Callback>> =>
+			this.call(
+				'GET',
+				`/events/account/${accountId}/events/callbacks/${callbackId}`,
+				{
+					transformResponse: transformCallbackResponse,
+				},
+				null,
+				'Get Callback'
+			),
+		create: (callback: Callback, accountId: string): Promise<Result<Callback>> =>
+			this.call(
+				'POST',
+				`/events/account/${accountId}/events/callbacks`,
+				{
+					transformResponse: transformCallbackResponse,
+					transformRequest: transformCallbackRequest,
+				},
+				callback,
+				'Create Callback'
+			),
+		update: (callback: Callback, accountId: string, callbackId: string): Promise<Result<Callback>> =>
+			this.call(
+				'PUT',
+				`/events/account/${accountId}/events/callbacks/${callbackId}`,
+				{
+					transformResponse: transformCallbackResponse,
+					transformRequest: transformCallbackRequest,
+				},
+				callback,
+				'Update Callback'
+			),
+		delete: (accountId: string, callbackId: string): Promise<Result<Callback>> =>
+			this.call(
+				'DELETE',
+				`/events/account/${accountId}/events/callbacks/${callbackId}`,
+				{},
+				null,
+				'Delete Callback'
+			),
+		verify: (accountId: string, callbackId: string, verifier: string): Promise<Result<Callback>> =>
+			this.call(
+				'PUT',
+				`/events/account/${accountId}/events/callbacks/${callbackId}`,
+				{
+					transformResponse: transformCallbackResponse,
+					transformRequest: transformCallbackVerifierRequest,
+				},
+				verifier,
+				'Verify Callback'
+			),
+		resendVerification: (accountId: string, callbackId: string): Promise<Result<Callback>> =>
+			this.call(
+				'PUT',
+				`/events/account/${accountId}/events/callbacks/${callbackId}`,
+				{
+					transformResponse: transformCallbackResponse,
+					transformRequest: transformCallbackResendRequest,
+				},
+				null,
+				'Verify Callback'
 			),
 	}
 }

--- a/packages/api/src/models/Callback.ts
+++ b/packages/api/src/models/Callback.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { transformErrorResponse, isEventErrorResponse, ErrorResponse } from './Error'
+import { Nullable } from './helpers'
+import Pagination from './Pagination'
+import { transformDateResponse, DateFormat } from './Date'
+
+export default interface Callback {
+	callbackId?: number
+	event: string
+	uri: string
+	verified?: boolean
+	updatedAt?: Nullable<Date>
+
+}
+export function transformCallbackData({
+	callbackid: callbackId,
+	uri,
+	event,
+	verified,
+	updated_at: updatedAt,
+}: any): Callback {
+	return {
+		callbackId,
+		uri,
+		event,
+		verified,
+		updatedAt: transformDateResponse(updatedAt, DateFormat['YYYY-MM-DD hh:mm:ss']),
+	}
+}
+
+export function transformCallbackResponse(data: string): Callback | ErrorResponse {
+	const response = JSON.parse(data)
+	if (isEventErrorResponse(response)) {
+		return transformErrorResponse(response)
+	}
+
+	const {
+		response: { result },
+	} = response
+	const { callback } = result
+	return transformCallbackData(callback)
+}
+
+/**
+ * Parses JSON list response and converts to internal callback list response
+ * @param data representing JSON response
+ * @returns callback list response
+ */
+ export function transformCallbackListResponse(data: string): { callbacks: Callback[]; pages: Pagination } | ErrorResponse {
+	const response = JSON.parse(data)
+
+	if (isEventErrorResponse(response)) {
+		return transformErrorResponse(response)
+	}
+	const {
+		response: { result },
+	} = response
+	const { callbacks, per_page, total, page, pages } = result
+	return {
+		pages: {
+			page,
+			pages,
+			size: per_page,
+			total,
+		},
+		callbacks: callbacks.map((callback: Callback) => transformCallbackData(callback)),
+	}
+}
+
+export function transformCallbackRequest(callback: Callback): string {
+	let payload = {
+		callback: {
+			uri: callback.uri,
+			event: callback.event,
+		}
+	}
+	const request = JSON.stringify(payload)
+	return request
+}
+
+export function transformCallbackVerifierRequest(verifier: string): string {
+	let payload = {
+		callback: {
+			verifier: verifier
+		}
+	}
+	const request = JSON.stringify(payload)
+	return request
+}
+
+export function transformCallbackResendRequest(): string {
+	let payload = {
+		callback: {
+			resend: true
+		}
+	}
+	const request = JSON.stringify(payload)
+	return request
+}

--- a/packages/api/src/models/Error.ts
+++ b/packages/api/src/models/Error.ts
@@ -31,6 +31,8 @@ export const isAccountingErrorResponse = ({ error, error_type: errorType, respon
 
 export const isProjectErrorResponse = ({ error, error_type: errorType }: any): any => error || errorType
 
+export const isEventErrorResponse = ({ errno, message }: any): any => errno || message
+
 export const transformErrorResponse = (errorResponse: any): ErrorResponse => {
 	const { response, error, errno, error_description: errorDescription, error_type: errorType, message } = errorResponse
 
@@ -77,6 +79,12 @@ export const transformErrorResponse = (errorResponse: any): ErrorResponse => {
 					message: error[key],
 				})
 			),
+		}
+	}
+	if (errno && message) {
+		return {
+			code: errno,
+			message: message,
 		}
 	}
 

--- a/packages/api/src/models/index.ts
+++ b/packages/api/src/models/index.ts
@@ -1,6 +1,7 @@
 export { default as BillPayments } from './BillPayments'
 export { default as Bills } from './Bills'
 export { default as BillVendors } from './BillVendors'
+export { default as Callback } from './Callback'
 export { default as Client } from './Client'
 export { default as CreditNote } from './CreditNote'
 export { default as Error } from './Error'


### PR DESCRIPTION
# Purpose

This will allow the SDK to perform CRUD operations on webhook callback
registrations as well as verify and trigger a verification resend.

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/12
<!-- Please do not reference internal bug trackers as this is a public project -->