### PR TITLE
✨ Allow marking invoices as sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Unreleased
 
+- Allow invoices to be marked as sent
+
 ### 3.0.0
 
 - (**Breaking Change**) `token` parameter removed from APIClient constructor, additional properties added to Client

--- a/packages/api/__tests__/Invoice.test.ts
+++ b/packages/api/__tests__/Invoice.test.ts
@@ -3,6 +3,7 @@ import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import Client, { Options } from '../src/APIClient'
 import { Invoice } from '../src/models'
+import { transformInvoiceRequest } from '../src/models/Invoices'
 import { IncludesQueryBuilder } from '../src/models/builders/IncludesQueryBuilder'
 import { SearchQueryBuilder } from '../src/models/builders/SearchQueryBuilder'
 
@@ -459,6 +460,13 @@ describe('@freshbooks/api', () => {
 			const invoice = buildInvoice({ visState: 1 })
 
 			expect(data).toEqual(invoice)
+		})
+		test('Mark Invoice As Sent - Action only payload item', async () => {
+			const invoice = buildInvoice()
+			invoice.actionMarkAsSent = true
+
+			const expected = '{"invoice":{"action_mark_as_sent":true}}'
+			expect(transformInvoiceRequest(invoice)).toEqual(expected)
 		})
 	})
 })

--- a/packages/api/src/models/Invoices.ts
+++ b/packages/api/src/models/Invoices.ts
@@ -68,6 +68,7 @@ export default interface Invoice {
 	id?: number
 	accountId?: string
 	accountingSystemId?: string
+	actionMarkAsSent?: Nullable<boolean>
 	address?: string
 	amount?: Money
 	autoBill?: boolean
@@ -301,6 +302,13 @@ export function transformInvoiceResponse(data: string): Invoice | ErrorResponse 
 }
 
 export function transformInvoiceRequest(invoice: Invoice): string {
+	if (invoice.actionMarkAsSent === true) {
+		return JSON.stringify({
+			invoice: {
+				action_mark_as_sent: true,
+			},
+		})
+	}
 	const request = JSON.stringify({
 		invoice: {
 			address: invoice.address,


### PR DESCRIPTION
# Purpose

Currently there is no way to mark an invoice as sent.

# Related Material

Fixes #251