### PR TITLE
SLAPI-598 Add Support for Profit and Loss Report

### DIFF
--- a/packages/api/__tests__/ProfitLossEntry.test.ts
+++ b/packages/api/__tests__/ProfitLossEntry.test.ts
@@ -1,0 +1,255 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import ProfitLossEntry, {
+	transformProfitLossEntryResponse,
+	transformProfitLossEntryResponseList,
+} from '../src/models/ProfitLossEntry'
+
+describe('@freshbooks/api', () => {
+	describe('ProfitLossEntry', () => {
+		describe('transformProfitLossEntryResponse', () => {
+			test('Verify JSON -> model transform for bare details', () => {
+				const json = `{
+					"children": [],
+					"data": [],
+					"description": "",
+					"entry_type": "none",
+					"total": {
+						"amount": "-61.95",
+						"code": "%"
+					}
+				}`
+				const response = JSON.parse(json)
+				const model = transformProfitLossEntryResponse(response)
+				const expected = {
+					children: [],
+					data: [],
+					description: '',
+					entryType: 'none',
+					total: {
+						amount: -61.95,
+						code: '%',
+					},
+				}
+				expect(model).toEqual(expected)
+			})
+			test('Verify JSON -> model transform single child', () => {
+				const json = `{
+					"children": [],
+					"data": [{
+						"amount": "8.85",
+						"code": "CAD"
+					}, {
+						"amount": "8.85",
+						"code": "CAD"
+					}],
+					"description": "Expenses",
+					"entry_type": "debit",
+					"total": {
+						"amount": "61.95",
+						"code": "CAD"
+					}
+				}`
+				const response = JSON.parse(json)
+				const model = transformProfitLossEntryResponse(response)
+				const expected = {
+					children: [],
+					data: [
+						{
+							amount: 8.85,
+							code: 'CAD',
+						},
+						{
+							amount: 8.85,
+							code: 'CAD',
+						},
+					],
+					description: 'Expenses',
+					entryType: 'debit',
+					total: {
+						amount: 61.95,
+						code: 'CAD',
+					},
+				}
+				expect(model).toEqual(expected)
+			})
+		})
+		describe('transformProfitLossEntryResponseList', () => {
+			test('Verify JSON -> model transform for empty children list', () => {
+				const json = `{"children": []}`
+				const response = JSON.parse(json)
+				const model = transformProfitLossEntryResponseList(response)
+				const expected: ProfitLossEntry[] = []
+				expect(model).toEqual(expected)
+			})
+
+			test('Verify JSON -> model transform for single child', () => {
+				const json = `[{
+					"children": [],
+					"data": [
+					{
+						"amount": "8.85",
+						"code": "CAD"
+					}
+					],
+					"description": "Expenses",
+					"entry_type": "debit",
+					"total": {
+					"amount": "61.95",
+					"code": "CAD"
+					}
+			  	}]`
+				const response = JSON.parse(json)
+				const model = transformProfitLossEntryResponseList(response)
+				const expected = [
+					{
+						children: [],
+						data: [
+							{
+								amount: 8.85,
+								code: 'CAD',
+							},
+						],
+						description: 'Expenses',
+						entryType: 'debit',
+						total: {
+							amount: 61.95,
+							code: 'CAD',
+						},
+					},
+				]
+				expect(model).toEqual(expected)
+			})
+			test('Verify JSON -> model transform for multiple children', () => {
+				const json = `[{
+				"children": [],
+				"data": [
+				  {
+					"amount": "8.85",
+					"code": "CAD"
+				  }
+				],
+				"description": "Expenses",
+				"entry_type": "debit",
+				"total": {
+				  "amount": "61.95",
+				  "code": "CAD"
+				}
+			  }, {
+				"children": [],
+				"data": [
+				  {
+					"amount": "8.85",
+					"code": "CAD"
+				  }
+				],
+				"description": "Personal",
+				"entry_type": "credit",
+				"total": {
+				  "amount": "61.95",
+				  "code": "CAD"
+				}
+			  }]`
+				const response = JSON.parse(json)
+				const model = transformProfitLossEntryResponseList(response)
+				const expected = [
+					{
+						children: [],
+						data: [
+							{
+								amount: 8.85,
+								code: 'CAD',
+							},
+						],
+						description: 'Expenses',
+						entryType: 'debit',
+						total: {
+							amount: 61.95,
+							code: 'CAD',
+						},
+					},
+					{
+						children: [],
+						data: [
+							{
+								amount: 8.85,
+								code: 'CAD',
+							},
+						],
+						description: 'Personal',
+						entryType: 'credit',
+						total: {
+							amount: 61.95,
+							code: 'CAD',
+						},
+					},
+				]
+				expect(model).toEqual(expected)
+			})
+
+			test('Verify JSON -> model transform for nested children', () => {
+				const json = `[{
+				"children": [{
+					"children": [],
+					"data": [{
+						"amount": "8.85",
+						"code": "CAD"
+					}],
+					"description": "Expenses",
+					"entry_type": "debit",
+					"total": {
+						"amount": "61.95",
+						"code": "CAD"
+					}
+				}],
+				"data": [{
+					"amount": "8.85",
+					"code": "CAD"
+				}],
+				"description": "Expenses",
+				"entry_type": "debit",
+				"total": {
+					"amount": "61.95",
+					"code": "CAD"
+				}
+			
+			}]`
+				const response = JSON.parse(json)
+				const model = transformProfitLossEntryResponseList(response)
+				const expected = [
+					{
+						children: [
+							{
+								children: [],
+								data: [
+									{
+										amount: 8.85,
+										code: 'CAD',
+									},
+								],
+								description: 'Expenses',
+								entryType: 'debit',
+								total: {
+									amount: 61.95,
+									code: 'CAD',
+								},
+							},
+						],
+						data: [
+							{
+								amount: 8.85,
+								code: 'CAD',
+							},
+						],
+						description: 'Expenses',
+						entryType: 'debit',
+						total: {
+							amount: 61.95,
+							code: 'CAD',
+						},
+					},
+				]
+				expect(model).toEqual(expected)
+			})
+		})
+	})
+})

--- a/packages/api/__tests__/ProfitLossReport.test.ts
+++ b/packages/api/__tests__/ProfitLossReport.test.ts
@@ -1,0 +1,620 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import Client, { Options } from '../src/APIClient'
+import { transformProfitLossReportData } from '../src/models/ProfitLossReport'
+
+const mock = new MockAdapter(axios)
+const ACCOUNT_ID = 'xZNQ1X'
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = { accessToken: 'token' }
+const PROFIT_LOSS_RESPONSE = JSON.stringify({
+	cash_based: false,
+	company_name: 'My Company',
+	currency_code: 'CAD',
+	dates: [
+		{
+			end_date: '2021-09-30',
+			start_date: '2021-09-01',
+		},
+		{
+			end_date: '2021-10-31',
+			start_date: '2021-10-01',
+		},
+	],
+	download_token: 'long.downloadtoken',
+	end_date: '2021-10-30',
+	expenses: [
+		{
+			children: [
+				{
+					children: [
+						{
+							children: [],
+							data: [
+								{
+									amount: '0.00',
+									code: 'CAD',
+								},
+								{
+									amount: '100.00',
+									code: 'CAD',
+								},
+							],
+							description: 'Bills',
+							entry_type: 'debit',
+							total: {
+								amount: '100.00',
+								code: 'CAD',
+							},
+						},
+					],
+					data: [
+						{
+							amount: '0.00',
+							code: 'CAD',
+						},
+						{
+							amount: '100.00',
+							code: 'CAD',
+						},
+					],
+					description: 'Office Expenses & Postage (general)',
+					entry_type: 'debit',
+					total: {
+						amount: '100.00',
+						code: 'CAD',
+					},
+				},
+			],
+			data: [
+				{
+					amount: '0.00',
+					code: 'CAD',
+				},
+				{
+					amount: '100.00',
+					code: 'CAD',
+				},
+			],
+			description: 'Office Expenses & Postage',
+			entry_type: 'debit',
+			total: {
+				amount: '100.00',
+				code: 'CAD',
+			},
+		},
+		{
+			children: [
+				{
+					children: [
+						{
+							children: [],
+							data: [
+								{
+									amount: '0.00',
+									code: 'CAD',
+								},
+								{
+									amount: '8.85',
+									code: 'CAD',
+								},
+							],
+							description: 'Expenses',
+							entry_type: 'debit',
+							total: {
+								amount: '8.85',
+								code: 'CAD',
+							},
+						},
+					],
+					data: [
+						{
+							amount: '0.00',
+							code: 'CAD',
+						},
+						{
+							amount: '8.85',
+							code: 'CAD',
+						},
+					],
+					description: 'Testing',
+					entry_type: 'debit',
+					total: {
+						amount: '8.85',
+						code: 'CAD',
+					},
+				},
+			],
+			data: [
+				{
+					amount: '0.00',
+					code: 'CAD',
+				},
+				{
+					amount: '8.85',
+					code: 'CAD',
+				},
+			],
+			description: 'Professional Services',
+			entry_type: 'debit',
+			total: {
+				amount: '8.85',
+				code: 'CAD',
+			},
+		},
+	],
+	gross_margin: {
+		children: [],
+		data: [
+			{
+				amount: '0.00',
+				code: '%',
+			},
+			{
+				amount: '100.00',
+				code: '%',
+			},
+		],
+		description: 'Gross Margin',
+		entry_type: 'none',
+		total: {
+			amount: '100.00',
+			code: '%',
+		},
+	},
+	net_profit: {
+		children: [],
+		data: [
+			{
+				amount: '0.00',
+				code: 'CAD',
+			},
+			{
+				amount: '1118.58',
+				code: 'CAD',
+			},
+		],
+		description: 'Net Profit (CAD)',
+		entry_type: 'credit',
+		total: {
+			amount: '1118.58',
+			code: 'CAD',
+		},
+	},
+	income: [
+		{
+			children: [
+				{
+					children: [],
+					data: [
+						{
+							amount: '0.00',
+							code: 'CAD',
+						},
+						{
+							amount: '-100.00',
+							code: 'CAD',
+						},
+					],
+					description: 'Credit',
+					entry_type: 'credit',
+					total: {
+						amount: '-100.00',
+						code: 'CAD',
+					},
+				},
+				{
+					children: [],
+					data: [
+						{
+							amount: '0.00',
+							code: 'CAD',
+						},
+						{
+							amount: '1327.43',
+							code: 'CAD',
+						},
+					],
+					description: 'Other Income',
+					entry_type: 'credit',
+					total: {
+						amount: '1327.43',
+						code: 'CAD',
+					},
+				},
+			],
+			data: [
+				{
+					amount: '0.00',
+					code: 'CAD',
+				},
+				{
+					amount: '1227.43',
+					code: 'CAD',
+				},
+			],
+			description: 'Sales',
+			entry_type: 'credit',
+			total: {
+				amount: '1227.43',
+				code: 'CAD',
+			},
+		},
+		{
+			children: [],
+			data: [
+				{
+					amount: '0.00',
+					code: 'CAD',
+				},
+				{
+					amount: '0.00',
+					code: 'CAD',
+				},
+			],
+			description: 'Cost of Goods Sold',
+			entry_type: 'credit',
+			total: {
+				amount: '0.00',
+				code: 'CAD',
+			},
+		},
+	],
+	labels: ['2021-09-01', '2021-10-01'],
+	resolution: 'm',
+	start_date: '2021-09-30',
+	total_expenses: {
+		children: [],
+		data: [
+			{
+				amount: '0.00',
+				code: 'CAD',
+			},
+			{
+				amount: '108.85',
+				code: 'CAD',
+			},
+		],
+		description: 'Total Expenses',
+		entry_type: 'debit',
+		total: {
+			amount: '108.85',
+			code: 'CAD',
+		},
+	},
+	total_income: {
+		children: [],
+		data: [
+			{
+				amount: '0.00',
+				code: 'CAD',
+			},
+			{
+				amount: '1227.43',
+				code: 'CAD',
+			},
+		],
+		description: 'Gross Profit',
+		entry_type: 'credit',
+		total: {
+			amount: '1227.43',
+			code: 'CAD',
+		},
+	},
+})
+
+const EXPECTED = {
+	cashBased: false,
+	companyName: 'My Company',
+	currencyCode: 'CAD',
+	downloadToken: 'long.downloadtoken',
+	startDate: '2021-09-30',
+	endDate: '2021-10-30',
+	resolution: 'm',
+	labels: ['2021-09-01', '2021-10-01'],
+	grossMargin: {
+		children: [],
+		data: [
+			{
+				amount: 0.0,
+				code: '%',
+			},
+			{
+				amount: 100.0,
+				code: '%',
+			},
+		],
+		description: 'Gross Margin',
+		entryType: 'none',
+		total: {
+			amount: 100.0,
+			code: '%',
+		},
+	},
+	netProfit: {
+		children: [],
+		data: [
+			{
+				amount: 0.0,
+				code: 'CAD',
+			},
+			{
+				amount: 1118.58,
+				code: 'CAD',
+			},
+		],
+		description: 'Net Profit (CAD)',
+		entryType: 'credit',
+		total: {
+			amount: 1118.58,
+			code: 'CAD',
+		},
+	},
+	expenses: [
+		{
+			children: [
+				{
+					children: [
+						{
+							children: [],
+							data: [
+								{
+									amount: 0.0,
+									code: 'CAD',
+								},
+								{
+									amount: 100.0,
+									code: 'CAD',
+								},
+							],
+							description: 'Bills',
+							entryType: 'debit',
+							total: {
+								amount: 100.0,
+								code: 'CAD',
+							},
+						},
+					],
+					data: [
+						{
+							amount: 0.0,
+							code: 'CAD',
+						},
+						{
+							amount: 100.0,
+							code: 'CAD',
+						},
+					],
+					description: 'Office Expenses & Postage (general)',
+					entryType: 'debit',
+					total: {
+						amount: 100.0,
+						code: 'CAD',
+					},
+				},
+			],
+			data: [
+				{
+					amount: 0.0,
+					code: 'CAD',
+				},
+				{
+					amount: 100.0,
+					code: 'CAD',
+				},
+			],
+			description: 'Office Expenses & Postage',
+			entryType: 'debit',
+			total: {
+				amount: 100.0,
+				code: 'CAD',
+			},
+		},
+		{
+			children: [
+				{
+					children: [
+						{
+							children: [],
+							data: [
+								{
+									amount: 0.0,
+									code: 'CAD',
+								},
+								{
+									amount: 8.85,
+									code: 'CAD',
+								},
+							],
+							description: 'Expenses',
+							entryType: 'debit',
+							total: {
+								amount: 8.85,
+								code: 'CAD',
+							},
+						},
+					],
+					data: [
+						{
+							amount: 0.0,
+							code: 'CAD',
+						},
+						{
+							amount: 8.85,
+							code: 'CAD',
+						},
+					],
+					description: 'Testing',
+					entryType: 'debit',
+					total: {
+						amount: 8.85,
+						code: 'CAD',
+					},
+				},
+			],
+			data: [
+				{
+					amount: 0.0,
+					code: 'CAD',
+				},
+				{
+					amount: 8.85,
+					code: 'CAD',
+				},
+			],
+			description: 'Professional Services',
+			entryType: 'debit',
+			total: {
+				amount: 8.85,
+				code: 'CAD',
+			},
+		},
+	],
+	income: [
+		{
+			children: [
+				{
+					children: [],
+					data: [
+						{
+							amount: 0.0,
+							code: 'CAD',
+						},
+						{
+							amount: -100.0,
+							code: 'CAD',
+						},
+					],
+					description: 'Credit',
+					entryType: 'credit',
+					total: {
+						amount: -100.0,
+						code: 'CAD',
+					},
+				},
+				{
+					children: [],
+					data: [
+						{
+							amount: 0.0,
+							code: 'CAD',
+						},
+						{
+							amount: 1327.43,
+							code: 'CAD',
+						},
+					],
+					description: 'Other Income',
+					entryType: 'credit',
+					total: {
+						amount: 1327.43,
+						code: 'CAD',
+					},
+				},
+			],
+			data: [
+				{
+					amount: 0.0,
+					code: 'CAD',
+				},
+				{
+					amount: 1227.43,
+					code: 'CAD',
+				},
+			],
+			description: 'Sales',
+			entryType: 'credit',
+			total: {
+				amount: 1227.43,
+				code: 'CAD',
+			},
+		},
+		{
+			children: [],
+			data: [
+				{
+					amount: 0.0,
+					code: 'CAD',
+				},
+				{
+					amount: 0.0,
+					code: 'CAD',
+				},
+			],
+			description: 'Cost of Goods Sold',
+			entryType: 'credit',
+			total: {
+				amount: 0.0,
+				code: 'CAD',
+			},
+		},
+	],
+	totalExpenses: {
+		children: [],
+		data: [
+			{
+				amount: 0.0,
+				code: 'CAD',
+			},
+			{
+				amount: 108.85,
+				code: 'CAD',
+			},
+		],
+		description: 'Total Expenses',
+		entryType: 'debit',
+		total: {
+			amount: 108.85,
+			code: 'CAD',
+		},
+	},
+	totalIncome: {
+		children: [],
+		data: [
+			{
+				amount: 0.0,
+				code: 'CAD',
+			},
+			{
+				amount: 1227.43,
+				code: 'CAD',
+			},
+		],
+		description: 'Gross Profit',
+		entryType: 'credit',
+		total: {
+			amount: 1227.43,
+			code: 'CAD',
+		},
+	},
+}
+describe('@freshbooks/api', () => {
+	describe('ProfitLossReport', () => {
+		describe('transformProfitLossReportData', () => {
+			test('Verify JSON -> model transform', () => {
+				const response = JSON.parse(PROFIT_LOSS_RESPONSE)
+				const model = transformProfitLossReportData(response)
+				expect(model).toEqual(EXPECTED)
+			})
+		})
+		describe('GET Call', () => {
+			test('GET /accounting/account/${accountId}/reports/accounting/profitloss_entity', async () => {
+				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
+				const mockResponse = `
+				{"response":
+					{
+						"result": {
+							"profitloss": ${PROFIT_LOSS_RESPONSE}
+						}
+					}
+				}`
+				mock
+					.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/profitloss_entity`)
+					.replyOnce(200, mockResponse)
+				const { data } = await client.reports.profitLoss(ACCOUNT_ID)
+				expect(data).toEqual(EXPECTED)
+			})
+		})
+	})
+})

--- a/packages/api/__tests__/ProfitLossReport.test.ts
+++ b/packages/api/__tests__/ProfitLossReport.test.ts
@@ -615,6 +615,38 @@ describe('@freshbooks/api', () => {
 				const { data } = await client.reports.profitLoss(ACCOUNT_ID)
 				expect(data).toEqual(EXPECTED)
 			})
+			test('Test not found errors', async () => {
+				const mockResponse = JSON.stringify({
+					error_type: 'not_found',
+					message: 'The requested resource was not found.',
+				})
+				mock
+					.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/profitloss_entity`)
+					.replyOnce(401, mockResponse)
+
+				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
+				try {
+					await client.reports.profitLoss(ACCOUNT_ID)
+				} catch (error: any) {
+					expect(error.code).toEqual('not_found')
+					expect(error.message).toEqual('The requested resource was not found.')
+				}
+			})
+
+			test('Test unhandled errors', async () => {
+				const unhandledError = new Error('Unhandled Error!')
+				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
+
+				client.reports.profitLoss = jest.fn(() => {
+					throw unhandledError
+				})
+
+				try {
+					await client.reports.profitLoss(ACCOUNT_ID)
+				} catch (error) {
+					expect(error).toBe(unhandledError)
+				}
+			})
 		})
 	})
 })

--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -79,6 +79,7 @@ import {
 	transformCallbackResendRequest,
 } from './models/Callback'
 import { transformPaymentOptionsRequest, transformPaymentOptionsResponse } from './models/PaymentOptions'
+import { transformProfitLossReportResponse } from './models/ProfitLossReport'
 
 // defaults
 const API_BASE_URL = 'https://api.freshbooks.com'
@@ -1274,6 +1275,22 @@ export default class APIClient {
 				},
 				null,
 				'Verify Callback'
+			),
+	}
+
+	public readonly reports = {
+		profitLoss: (
+			accountId: string,
+			queryBuilders?: QueryBuilderType[]
+		): Promise<Result<{ callbacks: Callback[]; pages: Pagination }>> =>
+			this.call(
+				'GET',
+				`/accounting/account/${accountId}/reports/accounting/profitloss_entity${joinQueries(queryBuilders)}`,
+				{
+					transformResponse: transformProfitLossReportResponse,
+				},
+				null,
+				'Profit and Loss Report'
 			),
 	}
 }

--- a/packages/api/src/models/ProfitLossEntry.ts
+++ b/packages/api/src/models/ProfitLossEntry.ts
@@ -1,0 +1,50 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import Money, { MoneyResponse, transformMoneyResponse } from './Money'
+
+enum ProfitLossEntryType {
+	debit = 'debit',
+	credit = 'credit',
+	none = 'none',
+}
+
+export default interface ProfitLossEntry {
+	entryType: ProfitLossEntryType
+	total: Money
+	data: Money[]
+	description: string
+	children: ProfitLossEntry[]
+}
+
+export interface ProfitLossEntryResponse {
+	entry_type: ProfitLossEntryType
+	total: MoneyResponse
+	data: MoneyResponse[]
+	description: string
+	children: ProfitLossEntryResponse[]
+}
+
+export function transformProfitLossEntryResponse(response: ProfitLossEntryResponse): ProfitLossEntry {
+	const childEntries =
+		response.children && response.children.length > 0
+			? response.children.map((child: ProfitLossEntryResponse) => transformProfitLossEntryResponse(child))
+			: []
+	const dataEntries =
+		response.data && response.data.length > 0
+			? response.data.map((dataEntry: MoneyResponse) => transformMoneyResponse(dataEntry))
+			: []
+	return {
+		children: childEntries,
+		data: dataEntries,
+		description: response.description,
+		entryType: response.entry_type,
+		total: response.total && transformMoneyResponse(response.total),
+	}
+}
+
+export function transformProfitLossEntryResponseList(data: ProfitLossEntryResponse[]): ProfitLossEntry[] {
+	if (data && data.length > 0) {
+		return data.map((child: ProfitLossEntryResponse) => transformProfitLossEntryResponse(child))
+	} else {
+		return []
+	}
+}

--- a/packages/api/src/models/ProfitLossReport.ts
+++ b/packages/api/src/models/ProfitLossReport.ts
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
+import ProfitLossEntry, {
+	ProfitLossEntryResponse,
+	transformProfitLossEntryResponse,
+	transformProfitLossEntryResponseList,
+} from './ProfitLossEntry'
+
+export default interface ProfitLossReport {
+	netProfit: ProfitLossEntry
+	totalIncome: ProfitLossEntry
+	totalExpenses: ProfitLossEntry
+	endDate: Date
+	income: ProfitLossEntry[]
+	expenses: ProfitLossEntry[]
+	grossMargin: ProfitLossEntry
+	labels: Date[]
+	downloadToken: string
+	companyName: string
+	cashBased: boolean
+	resolution?: string
+	startDate: Date
+	currencyCode: string
+}
+
+interface ProfitLossReportResponse {
+	net_profit: ProfitLossEntryResponse
+	total_income: ProfitLossEntryResponse
+	total_expenses: ProfitLossEntryResponse
+	end_date: Date
+	income: ProfitLossEntryResponse[]
+	expenses: ProfitLossEntryResponse[]
+	gross_margin: ProfitLossEntryResponse
+	labels: Date[]
+	download_token: string
+	company_name: string
+	cash_based: boolean
+	resolution?: string
+	start_date: Date
+	currency_code: string
+}
+
+export function transformProfitLossReportData({
+	cash_based,
+	company_name,
+	currency_code,
+	labels,
+	download_token,
+	end_date,
+	expenses,
+	gross_margin,
+	income,
+	net_profit,
+	resolution,
+	start_date,
+	total_expenses,
+	total_income,
+}: ProfitLossReportResponse): ProfitLossReport {
+	return {
+		companyName: company_name,
+		currencyCode: currency_code,
+		cashBased: cash_based,
+		startDate: start_date,
+		endDate: end_date,
+		resolution: resolution,
+		labels: labels,
+		downloadToken: download_token,
+		expenses: expenses && transformProfitLossEntryResponseList(expenses),
+		grossMargin: gross_margin && transformProfitLossEntryResponse(gross_margin),
+		income: income && transformProfitLossEntryResponseList(income),
+		netProfit: net_profit && transformProfitLossEntryResponse(net_profit),
+		totalExpenses: total_expenses && transformProfitLossEntryResponse(total_expenses),
+		totalIncome: total_income && transformProfitLossEntryResponse(total_income),
+	}
+}
+
+/**
+ * Parses JSON ProfitLossReport response and converts to @ProfitLossReport model
+ * @param data representing JSON response
+ * @returns @ProfitLossReport | @Error
+ */
+export function transformProfitLossReportResponse(data: string): ProfitLossReport | ErrorResponse {
+	const response = JSON.parse(data)
+	if (isAccountingErrorResponse(response)) {
+		return transformErrorResponse(response)
+	}
+	const {
+		response: { result },
+	} = response
+	const { profitloss } = result
+	return transformProfitLossReportData(profitloss)
+}

--- a/packages/api/src/models/ProfitLossReport.ts
+++ b/packages/api/src/models/ProfitLossReport.ts
@@ -7,20 +7,20 @@ import ProfitLossEntry, {
 } from './ProfitLossEntry'
 
 export default interface ProfitLossReport {
-	netProfit: ProfitLossEntry
-	totalIncome: ProfitLossEntry
-	totalExpenses: ProfitLossEntry
-	endDate: Date
-	income: ProfitLossEntry[]
-	expenses: ProfitLossEntry[]
-	grossMargin: ProfitLossEntry
-	labels: Date[]
-	downloadToken: string
 	companyName: string
+	currencyCode: string
 	cashBased: boolean
 	resolution?: string
 	startDate: Date
-	currencyCode: string
+	endDate: Date
+	downloadToken: string
+	labels: Date[]
+	netProfit: ProfitLossEntry
+	totalIncome: ProfitLossEntry
+	totalExpenses: ProfitLossEntry
+	grossMargin: ProfitLossEntry
+	income: ProfitLossEntry[]
+	expenses: ProfitLossEntry[]
 }
 
 interface ProfitLossReportResponse {


### PR DESCRIPTION
# Purpose
Add SDK support for Profit and Loss Report. 
API Specs: https://www.freshbooks.com/api/reports

# Related Material
Added tests. The data in `ProfitLossReport.test.ts` mirrors this report. 
![Screen Shot 2022-05-16 at 11 08 57 AM](https://user-images.githubusercontent.com/94197095/168624913-e6d7a8f8-3a6e-428f-9572-e09dbe8e87d1.png)