### PR TITLE
[Reports] Add support for Tax Summary Report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Allow invoices to be marked as sent
 - Support for Profit & Loss Report 
+- Support for Tax Summary Report
 
 ### 3.0.0
 

--- a/packages/api/__tests__/TaxSummaryReport.test.ts
+++ b/packages/api/__tests__/TaxSummaryReport.test.ts
@@ -1,0 +1,222 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import Client, { Options } from '../src/APIClient'
+import { transformTaxSummaryReportData } from '../src/models/TaxSummaryReport'
+
+const mock = new MockAdapter(axios)
+const ACCOUNT_ID = 'xZNQ1X'
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = { accessToken: 'token' }
+const TAX_REPORT_RESPONSE = JSON.stringify({
+	cash_based: false,
+	currency_code: 'CAD',
+	download_token: 'long.downloadtoken',
+	end_date: '2022-09-30',
+	start_date: '2021-10-01',
+	taxes: [
+		{
+			net_tax: {
+				amount: '3.13',
+				code: 'CAD',
+			},
+			net_taxable_amount: {
+				amount: '50.00',
+				code: 'CAD',
+			},
+			tax_collected: {
+				amount: '3.13',
+				code: 'CAD',
+			},
+			tax_name: 'GST',
+			tax_paid: {
+				amount: '0.00',
+				code: 'CAD',
+			},
+			taxable_amount_collected: {
+				amount: '50.00',
+				code: 'CAD',
+			},
+			taxable_amount_paid: {
+				amount: '0.00',
+				code: 'CAD',
+			},
+		},
+		{
+			net_tax: {
+				amount: '163.37',
+				code: 'CAD',
+			},
+			net_taxable_amount: {
+				amount: '1256.63',
+				code: 'CAD',
+			},
+			tax_collected: {
+				amount: '172.57',
+				code: 'CAD',
+			},
+			tax_name: 'HST',
+			tax_paid: {
+				amount: '9.20',
+				code: 'CAD',
+			},
+			taxable_amount_collected: {
+				amount: '1327.43',
+				code: 'CAD',
+			},
+			taxable_amount_paid: {
+				amount: '70.80',
+				code: 'CAD',
+			},
+		},
+	],
+	total_invoiced: {
+		amount: '1503.13',
+		code: 'CAD',
+	},
+})
+
+const EXPECTED = {
+	cashBased: false,
+	currencyCode: 'CAD',
+	downloadToken: 'long.downloadtoken',
+	endDate: '2022-09-30',
+	startDate: '2021-10-01',
+	taxes: [
+		{
+			netTax: {
+				amount: 3.13,
+				code: 'CAD',
+			},
+			netTaxableAmount: {
+				amount: 50.0,
+				code: 'CAD',
+			},
+			taxCollected: {
+				amount: 3.13,
+				code: 'CAD',
+			},
+			taxName: 'GST',
+			taxPaid: {
+				amount: 0.0,
+				code: 'CAD',
+			},
+			taxableAmountCollected: {
+				amount: 50.0,
+				code: 'CAD',
+			},
+			taxableAmountPaid: {
+				amount: 0.0,
+				code: 'CAD',
+			},
+		},
+		{
+			netTax: {
+				amount: 163.37,
+				code: 'CAD',
+			},
+			netTaxableAmount: {
+				amount: 1256.63,
+				code: 'CAD',
+			},
+			taxCollected: {
+				amount: 172.57,
+				code: 'CAD',
+			},
+			taxName: 'HST',
+			taxPaid: {
+				amount: 9.2,
+				code: 'CAD',
+			},
+			taxableAmountCollected: {
+				amount: 1327.43,
+				code: 'CAD',
+			},
+			taxableAmountPaid: {
+				amount: 70.8,
+				code: 'CAD',
+			},
+		},
+	],
+	totalInvoiced: {
+		amount: 1503.13,
+		code: 'CAD',
+	},
+}
+describe('@freshbooks/api', () => {
+	describe('TaxSummaryReport', () => {
+		describe('transformTaxSummaryReportData', () => {
+			test('Verify JSON -> model transform', () => {
+				const response = JSON.parse(TAX_REPORT_RESPONSE)
+				const model = transformTaxSummaryReportData(response)
+				expect(model).toEqual(EXPECTED)
+			})
+		})
+		describe('transformTaxSummaryReportData', () => {
+			test('Verify JSON -> model transform - empty tax list', () => {
+				const response = JSON.parse(
+					JSON.stringify({
+						cash_based: false,
+						currency_code: 'USD',
+						download_token: 'long.downloadtoken',
+						end_date: '2022-09-30',
+						start_date: '2021-10-01',
+						taxes: [],
+						total_invoiced: {
+							amount: '0.00',
+							code: 'USD',
+						},
+					})
+				)
+				const model = transformTaxSummaryReportData(response)
+				expect(model.taxes).toEqual([])
+			})
+		})
+		describe('GET Call', () => {
+			test('GET /accounting/account/${accountId}/reports/accounting/taxsummary', async () => {
+				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
+				const mockResponse = `
+				{"response":
+					{
+						"result": {
+							"taxsummary": ${TAX_REPORT_RESPONSE}
+						}
+					}
+				}`
+				mock.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/taxsummary`).replyOnce(200, mockResponse)
+				const { data } = await client.reports.taxSummary(ACCOUNT_ID)
+				expect(data).toEqual(EXPECTED)
+			})
+			test('Test not found errors', async () => {
+				const mockResponse = JSON.stringify({
+					error_type: 'not_found',
+					message: 'The requested resource was not found.',
+				})
+				mock.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/taxsummary`).replyOnce(401, mockResponse)
+
+				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
+				try {
+					await client.reports.taxSummary(ACCOUNT_ID)
+				} catch (error: any) {
+					expect(error.code).toEqual('not_found')
+					expect(error.message).toEqual('The requested resource was not found.')
+				}
+			})
+
+			test('Test unhandled errors', async () => {
+				const unhandledError = new Error('Unhandled Error!')
+				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
+
+				client.reports.taxSummary = jest.fn(() => {
+					throw unhandledError
+				})
+
+				try {
+					await client.reports.taxSummary(ACCOUNT_ID)
+				} catch (error) {
+					expect(error).toBe(unhandledError)
+				}
+			})
+		})
+	})
+})

--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -80,6 +80,7 @@ import {
 } from './models/Callback'
 import { transformPaymentOptionsRequest, transformPaymentOptionsResponse } from './models/PaymentOptions'
 import { transformProfitLossReportResponse } from './models/ProfitLossReport'
+import { transformTaxSummaryReportResponse } from './models/TaxSummaryReport'
 
 // defaults
 const API_BASE_URL = 'https://api.freshbooks.com'
@@ -1291,6 +1292,19 @@ export default class APIClient {
 				},
 				null,
 				'Profit and Loss Report'
+			),
+		taxSummary: (
+			accountId: string,
+			queryBuilders?: QueryBuilderType[]
+		): Promise<Result<{ callbacks: Callback[]; pages: Pagination }>> =>
+			this.call(
+				'GET',
+				`/accounting/account/${accountId}/reports/accounting/taxsummary${joinQueries(queryBuilders)}`,
+				{
+					transformResponse: transformTaxSummaryReportResponse,
+				},
+				null,
+				'Tax Summary Report'
 			),
 	}
 }

--- a/packages/api/src/models/TaxSummaryEntry.ts
+++ b/packages/api/src/models/TaxSummaryEntry.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import Money, { MoneyResponse, transformMoneyResponse } from './Money'
+
+export default interface TaxSummaryEntry {
+	taxName: string
+	netTax: Money
+	netTaxableAmount: Money
+	taxCollected: Money
+	taxPaid: Money
+	taxableAmountCollected: Money
+	taxableAmountPaid: Money
+}
+
+export interface TaxSummaryEntryResponse {
+	tax_name: string
+	net_tax: MoneyResponse
+	net_taxable_amount: MoneyResponse
+	tax_collected: MoneyResponse
+	tax_paid: MoneyResponse
+	taxable_amount_collected: MoneyResponse
+	taxable_amount_paid: MoneyResponse
+}
+
+export function transformTaxSummaryEntryRespone(response: TaxSummaryEntryResponse): TaxSummaryEntry {
+	return {
+		taxName: response.tax_name,
+		netTax: response.net_tax && transformMoneyResponse(response.net_tax),
+		netTaxableAmount: response.net_taxable_amount && transformMoneyResponse(response.net_taxable_amount),
+		taxCollected: response.tax_collected && transformMoneyResponse(response.tax_collected),
+		taxPaid: response.tax_paid && transformMoneyResponse(response.tax_paid),
+		taxableAmountCollected:
+			response.taxable_amount_collected && transformMoneyResponse(response.taxable_amount_collected),
+		taxableAmountPaid: response.taxable_amount_paid && transformMoneyResponse(response.taxable_amount_paid),
+	}
+}
+
+export function transformTaxSummaryEntryResponeList(data: TaxSummaryEntryResponse[]): TaxSummaryEntry[] {
+	if (data && data.length > 0) {
+		return data.map((child: TaxSummaryEntryResponse) => transformTaxSummaryEntryRespone(child))
+	} else {
+		return []
+	}
+}

--- a/packages/api/src/models/TaxSummaryReport.ts
+++ b/packages/api/src/models/TaxSummaryReport.ts
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
+import Money, { MoneyResponse, transformMoneyResponse } from './Money'
+import TaxSummaryEntry, { TaxSummaryEntryResponse, transformTaxSummaryEntryResponeList } from './TaxSummaryEntry'
+
+export default interface TaxSummaryReport {
+	currencyCode: string
+	cashBased: boolean
+	startDate: Date
+	endDate: Date
+	downloadToken: string
+	taxes: TaxSummaryEntry[]
+	totalInvoiced: Money
+}
+
+interface TaxSummaryReportResponse {
+	cash_based: boolean
+	start_date: Date
+	currency_code: string
+	end_date: Date
+	download_token: string
+	taxes: TaxSummaryEntryResponse[]
+	total_invoiced: MoneyResponse
+}
+
+export function transformTaxSummaryReportData({
+	cash_based,
+	currency_code,
+	download_token,
+	start_date,
+	end_date,
+	taxes,
+	total_invoiced,
+}: TaxSummaryReportResponse): TaxSummaryReport {
+	return {
+		currencyCode: currency_code,
+		cashBased: cash_based,
+		startDate: start_date,
+		endDate: end_date,
+		downloadToken: download_token,
+		totalInvoiced: total_invoiced && transformMoneyResponse(total_invoiced),
+		taxes: transformTaxSummaryEntryResponeList(taxes),
+	}
+}
+
+/**
+ * Parses JSON TaxSummaryReport response and converts to @TaxSummaryReport model
+ * @param data representing JSON response
+ * @returns @TaxSummaryReport | @Error
+ */
+export function transformTaxSummaryReportResponse(data: string): TaxSummaryReport | ErrorResponse {
+	const response = JSON.parse(data)
+	if (isAccountingErrorResponse(response)) {
+		return transformErrorResponse(response)
+	}
+	const {
+		response: { result },
+	} = response
+	const { taxsummary } = result
+	return transformTaxSummaryReportData(taxsummary)
+}


### PR DESCRIPTION
# Purpose
Add support for Tax Summary Report
API Specs: https://www.freshbooks.com/api/reports

# Related Material
Main test data based on
<img width="768" alt="Screen Shot 2022-05-30 at 5 44 31 PM" src="https://user-images.githubusercontent.com/94197095/171233827-64782810-10ac-484d-8027-aa2a2f306ed0.png">
 