### PR TITLE
Add support for payments collected report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow invoices to be marked as sent
 - Support for Profit & Loss Report 
 - Support for Tax Summary Report
+- Support for Payments Collected Report
 
 ### 3.0.0
 

--- a/packages/api/__tests__/PaymentsCollectedReport.test.ts
+++ b/packages/api/__tests__/PaymentsCollectedReport.test.ts
@@ -1,0 +1,256 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+import Client, { Options } from '../src/APIClient'
+import { SearchQueryBuilder } from '../src/models/builders/SearchQueryBuilder'
+import { transformPaymentsCollectedReportData } from '../src/models/report/PaymentsCollectedReport'
+
+const mock = new MockAdapter(axios)
+const ACCOUNT_ID = 'xZNQ1X'
+const APPLICATION_CLIENT_ID = 'test-client-id'
+const testOptions: Options = { accessToken: 'token' }
+const PAYMENTS_COLLECTED_REPORT_RESPONSE = JSON.stringify({
+	clientids: [12345, 54321],
+	currency_codes: ['CAD', 'EUR'],
+	download_token: 'long.downloadtoken',
+	end_date: '2022-09-30',
+	payment_methods: ['Cash', 'Check', 'Credit'],
+	payments: [
+		{
+			amount: {
+				amount: '53.13',
+				code: 'EUR',
+			},
+			client: 'French Press',
+			clientid: 54321,
+			credit_number: null,
+			creditid: null,
+			date: '2021-11-09',
+			description: 'AK',
+			from_credit: false,
+			invoice_number: 'AF100529',
+			invoiceid: 91210,
+			method: 'Check',
+		},
+		{
+			amount: {
+				amount: '100.00',
+				code: 'CAD',
+			},
+			client: 'test',
+			clientid: 12345,
+			credit_number: '0000003',
+			creditid: 976,
+			date: '2021-10-29',
+			description: '',
+			from_credit: false,
+			invoice_number: null,
+			invoiceid: null,
+			method: 'Credit',
+		},
+		{
+			amount: {
+				amount: '400.00',
+				code: 'CAD',
+			},
+			client: 'test',
+			clientid: 12345,
+			credit_number: '0000001',
+			creditid: 974,
+			date: '2021-10-29',
+			description: 'Overpayment: invoice #AF100520',
+			from_credit: false,
+			invoice_number: null,
+			invoiceid: null,
+			method: 'Cash',
+		},
+	],
+	start_date: '2021-10-01',
+	summary_only: false,
+	totals: [
+		{
+			amount: '500.00',
+			code: 'CAD',
+		},
+		{
+			amount: '53.13',
+			code: 'EUR',
+		},
+	],
+})
+const EXPECTED = {
+	clientIds: [12345, 54321],
+	currencyCodes: ['CAD', 'EUR'],
+	downloadToken: 'long.downloadtoken',
+	endDate: '2022-09-30',
+	paymentMethods: ['Cash', 'Check', 'Credit'],
+	payments: [
+		{
+			amount: {
+				amount: 53.13,
+				code: 'EUR',
+			},
+			client: 'French Press',
+			clientId: 54321,
+			creditNumber: null,
+			creditId: null,
+			date: '2021-11-09',
+			description: 'AK',
+			fromCredit: false,
+			invoiceNumber: 'AF100529',
+			invoiceId: 91210,
+			method: 'Check',
+		},
+		{
+			amount: {
+				amount: 100.0,
+				code: 'CAD',
+			},
+			client: 'test',
+			clientId: 12345,
+			creditNumber: '0000003',
+			creditId: 976,
+			date: '2021-10-29',
+			description: '',
+			fromCredit: false,
+			invoiceNumber: null,
+			invoiceId: null,
+			method: 'Credit',
+		},
+		{
+			amount: {
+				amount: 400.0,
+				code: 'CAD',
+			},
+			client: 'test',
+			clientId: 12345,
+			creditNumber: '0000001',
+			creditId: 974,
+			date: '2021-10-29',
+			description: 'Overpayment: invoice #AF100520',
+			fromCredit: false,
+			invoiceNumber: null,
+			invoiceId: null,
+			method: 'Cash',
+		},
+	],
+	startDate: '2021-10-01',
+	totals: [
+		{
+			amount: 500.0,
+			code: 'CAD',
+		},
+		{
+			amount: 53.13,
+			code: 'EUR',
+		},
+	],
+}
+
+describe('@freshbooks/api', () => {
+	describe('PaymentsCollectedReport', () => {
+		describe('transformPaymentsCollectedReportData', () => {
+			test('Verify JSON -> model transform', () => {
+				const response = JSON.parse(PAYMENTS_COLLECTED_REPORT_RESPONSE)
+				const model = transformPaymentsCollectedReportData(response)
+				expect(model).toEqual(EXPECTED)
+			})
+			test('Verify JSON -> model transform - empty payments collected list', () => {
+				const empty_test_data = {
+					clientids: [],
+					currency_codes: [],
+					download_token: 'long.downloadtoken',
+					end_date: '2017-09-30',
+					payment_methods: [],
+					payments: [],
+					start_date: '2016-10-01',
+					summary_only: false,
+					totals: [],
+				}
+				const expected_empty_response = {
+					clientIds: [],
+					currencyCodes: [],
+					downloadToken: 'long.downloadtoken',
+					endDate: '2017-09-30',
+					paymentMethods: [],
+					payments: [],
+					startDate: '2016-10-01',
+					totals: [],
+				}
+				const response = JSON.parse(JSON.stringify(empty_test_data))
+				const model = transformPaymentsCollectedReportData(response)
+				expect(model).toEqual(expected_empty_response)
+			})
+		})
+
+		describe('GET Call', () => {
+			test('GET /accounting/account/${accountId}/reports/accounting/payments_collected', async () => {
+				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
+				const mockResponse = `
+				{"response":
+					{
+						"result": {
+							"payments_collected": ${PAYMENTS_COLLECTED_REPORT_RESPONSE}
+						}
+					}
+				}`
+				mock
+					.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/payments_collected`)
+					.replyOnce(200, mockResponse)
+				const { data } = await client.reports.paymentsCollected(ACCOUNT_ID)
+				expect(data).toEqual(EXPECTED)
+			})
+
+			test('GET /accounting/account/${accountId}/reports/accounting/payments_collected with params', async () => {
+				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
+				const mockResponse = `
+				{"response":
+					{
+						"result": {
+							"payments_collected": ${PAYMENTS_COLLECTED_REPORT_RESPONSE}
+						}
+					}
+				}`
+				const builder = new SearchQueryBuilder().equals('currency_code', 'CAD')
+				mock
+					.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/payments_collected?${builder.build()}`)
+					.replyOnce(200, mockResponse)
+				const { data } = await client.reports.paymentsCollected(ACCOUNT_ID, [builder])
+				expect(data).toEqual(EXPECTED)
+			})
+
+			test('Test not found errors', async () => {
+				const mockResponse = JSON.stringify({
+					error_type: 'not_found',
+					message: 'The requested resource was not found.',
+				})
+				mock
+					.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/payments_collected`)
+					.replyOnce(401, mockResponse)
+
+				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
+				try {
+					await client.reports.paymentsCollected(ACCOUNT_ID)
+				} catch (error: any) {
+					expect(error.code).toEqual('not_found')
+					expect(error.message).toEqual('The requested resource was not found.')
+				}
+			})
+
+			test('Test unhandled errors', async () => {
+				const unhandledError = new Error('Unhandled Error!')
+				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
+
+				client.reports.paymentsCollected = jest.fn(() => {
+					throw unhandledError
+				})
+
+				try {
+					await client.reports.paymentsCollected(ACCOUNT_ID)
+				} catch (error) {
+					expect(error).toBe(unhandledError)
+				}
+			})
+		})
+	})
+})

--- a/packages/api/__tests__/ProfitLossEntry.test.ts
+++ b/packages/api/__tests__/ProfitLossEntry.test.ts
@@ -2,7 +2,7 @@
 import ProfitLossEntry, {
 	transformProfitLossEntryResponse,
 	transformProfitLossEntryResponseList,
-} from '../src/models/ProfitLossEntry'
+} from '../src/models/report/ProfitLossEntry'
 
 describe('@freshbooks/api', () => {
 	describe('ProfitLossEntry', () => {

--- a/packages/api/__tests__/ProfitLossReport.test.ts
+++ b/packages/api/__tests__/ProfitLossReport.test.ts
@@ -2,7 +2,7 @@
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import Client, { Options } from '../src/APIClient'
-import { transformProfitLossReportData } from '../src/models/ProfitLossReport'
+import { transformProfitLossReportData } from '../src/models/report/ProfitLossReport'
 
 const mock = new MockAdapter(axios)
 const ACCOUNT_ID = 'xZNQ1X'

--- a/packages/api/__tests__/TaxSummaryReport.test.ts
+++ b/packages/api/__tests__/TaxSummaryReport.test.ts
@@ -2,7 +2,7 @@
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import Client, { Options } from '../src/APIClient'
-import { transformTaxSummaryReportData } from '../src/models/TaxSummaryReport'
+import { transformTaxSummaryReportData } from '../src/models/report/TaxSummaryReport'
 
 const mock = new MockAdapter(axios)
 const ACCOUNT_ID = 'xZNQ1X'

--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -79,8 +79,9 @@ import {
 	transformCallbackResendRequest,
 } from './models/Callback'
 import { transformPaymentOptionsRequest, transformPaymentOptionsResponse } from './models/PaymentOptions'
-import { transformProfitLossReportResponse } from './models/ProfitLossReport'
-import { transformTaxSummaryReportResponse } from './models/TaxSummaryReport'
+import { transformProfitLossReportResponse } from './models/report/ProfitLossReport'
+import { transformTaxSummaryReportResponse } from './models/report/TaxSummaryReport'
+import { transformPaymentsCollectedReportResponse } from './models/report/PaymentsCollectedReport'
 
 // defaults
 const API_BASE_URL = 'https://api.freshbooks.com'
@@ -1305,6 +1306,19 @@ export default class APIClient {
 				},
 				null,
 				'Tax Summary Report'
+			),
+		paymentsCollected: (
+			accountId: string,
+			queryBuilders?: QueryBuilderType[]
+		): Promise<Result<{ callbacks: Callback[]; pages: Pagination }>> =>
+			this.call(
+				'GET',
+				`/accounting/account/${accountId}/reports/accounting/payments_collected${joinQueries(queryBuilders)}`,
+				{
+					transformResponse: transformPaymentsCollectedReportResponse,
+				},
+				null,
+				'Payments Collected Report'
 			),
 	}
 }

--- a/packages/api/src/models/report/PaymentsCollectedEntry.ts
+++ b/packages/api/src/models/report/PaymentsCollectedEntry.ts
@@ -1,0 +1,58 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import Money, { MoneyResponse, transformMoneyResponse } from '../Money'
+
+export default interface PaymentsCollectedEntry {
+	amount: Money
+	client: string
+	clientId: number
+	creditNumber?: string
+	creditId?: number
+	date: Date
+	description: string
+	fromCredit: boolean
+	invoiceNumber?: string
+	invoiceId?: number
+	method: string
+}
+
+export interface PaymentsCollectedEntryResponse {
+	amount: MoneyResponse
+	client: string
+	clientid: number
+	credit_number?: string
+	creditid?: number
+	date: Date
+	description: string
+	from_credit: boolean
+	invoice_number?: string
+	invoiceid?: number
+	method: string
+}
+
+export function transformPaymentsCollectedEntryRespone(
+	response: PaymentsCollectedEntryResponse
+): PaymentsCollectedEntry {
+	return {
+		amount: response.amount && transformMoneyResponse(response.amount),
+		client: response.client,
+		clientId: response.clientid,
+		creditNumber: response.credit_number,
+		creditId: response.creditid,
+		date: response.date,
+		description: response.description,
+		fromCredit: response.from_credit,
+		invoiceNumber: response.invoice_number,
+		invoiceId: response.invoiceid,
+		method: response.method,
+	}
+}
+
+export function transformPaymentsCollectedEntryResponeList(
+	data: PaymentsCollectedEntryResponse[]
+): PaymentsCollectedEntry[] {
+	if (data && data.length > 0) {
+		return data.map((child: PaymentsCollectedEntryResponse) => transformPaymentsCollectedEntryRespone(child))
+	} else {
+		return []
+	}
+}

--- a/packages/api/src/models/report/PaymentsCollectedReport.ts
+++ b/packages/api/src/models/report/PaymentsCollectedReport.ts
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from '../Error'
+import Money, { MoneyResponse, transformMoneyResponse } from '../Money'
+import PaymentsCollectedEntry, {
+	PaymentsCollectedEntryResponse,
+	transformPaymentsCollectedEntryResponeList,
+} from './PaymentsCollectedEntry'
+
+export default interface PaymentsCollectedReport {
+	currencyCodes: string[]
+	clientIds: number[]
+	startDate: Date
+	endDate: Date
+	downloadToken: string
+	paymentMethods: string[]
+	payments: PaymentsCollectedEntry[]
+	totals: Money[]
+}
+
+interface PaymentsCollectedReportResponse {
+	currency_codes: string[]
+	clientids: number[]
+	start_date: Date
+	end_date: Date
+	download_token: string
+	payment_methods: string[]
+	payments: PaymentsCollectedEntryResponse[]
+	summary_only: boolean
+	totals: MoneyResponse[]
+}
+
+export function transformPaymentsCollectedReportData({
+	currency_codes,
+	clientids,
+	start_date,
+	end_date,
+	download_token,
+	payment_methods,
+	payments,
+	totals,
+}: PaymentsCollectedReportResponse): PaymentsCollectedReport {
+	return {
+		currencyCodes: currency_codes,
+		clientIds: clientids,
+		startDate: start_date,
+		endDate: end_date,
+		downloadToken: download_token,
+		paymentMethods: payment_methods,
+		payments: payments && transformPaymentsCollectedEntryResponeList(payments),
+		totals: totals && totals.map((moneyResponse: MoneyResponse) => transformMoneyResponse(moneyResponse)),
+	}
+}
+
+/**
+ * Parses JSON PaymentsCollectedReport response and converts to @PaymentsCollectedReport model
+ * @param data representing JSON response
+ * @returns @PaymentsCollectedReport | @Error
+ */
+export function transformPaymentsCollectedReportResponse(data: string): PaymentsCollectedReport | ErrorResponse {
+	const response = JSON.parse(data)
+	if (isAccountingErrorResponse(response)) {
+		return transformErrorResponse(response)
+	}
+	const {
+		response: { result },
+	} = response
+	const { payments_collected } = result
+	return transformPaymentsCollectedReportData(payments_collected)
+}

--- a/packages/api/src/models/report/ProfitLossEntry.ts
+++ b/packages/api/src/models/report/ProfitLossEntry.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import Money, { MoneyResponse, transformMoneyResponse } from './Money'
+import Money, { MoneyResponse, transformMoneyResponse } from '../Money'
 
 enum ProfitLossEntryType {
 	debit = 'debit',

--- a/packages/api/src/models/report/ProfitLossReport.ts
+++ b/packages/api/src/models/report/ProfitLossReport.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
+import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from '../Error'
 import ProfitLossEntry, {
 	ProfitLossEntryResponse,
 	transformProfitLossEntryResponse,

--- a/packages/api/src/models/report/TaxSummaryEntry.ts
+++ b/packages/api/src/models/report/TaxSummaryEntry.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import Money, { MoneyResponse, transformMoneyResponse } from './Money'
+import Money, { MoneyResponse, transformMoneyResponse } from '../Money'
 
 export default interface TaxSummaryEntry {
 	taxName: string

--- a/packages/api/src/models/report/TaxSummaryReport.ts
+++ b/packages/api/src/models/report/TaxSummaryReport.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
-import Money, { MoneyResponse, transformMoneyResponse } from './Money'
+import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from '../Error'
+import Money, { MoneyResponse, transformMoneyResponse } from '../Money'
 import TaxSummaryEntry, { TaxSummaryEntryResponse, transformTaxSummaryEntryResponeList } from './TaxSummaryEntry'
 
 export default interface TaxSummaryReport {


### PR DESCRIPTION
# Purpose
Moved Report models to their own folder. 
Added support for Payments Collected Report 

# Related Material
API Specs: https://www.freshbooks.com/api/reports
Main test based on the below sample report
<img width="804" alt="Payments Collected Report" src="https://user-images.githubusercontent.com/94197095/172944621-8898eede-f24b-4455-a856-6b6ccc927596.png">

