### PR TITLE
📝 Add typedoc config

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         rm -rf docs
         cd packages/api
-        npx typedoc --out ../../docs src/index.ts
+        npx typedoc
     - name: Commit files
       run: |
         echo ${{ github.ref }}

--- a/packages/api/typedoc.json
+++ b/packages/api/typedoc.json
@@ -1,0 +1,10 @@
+{
+  "entryPoints": [
+    "src",
+    "src/models",
+    "src/models/builders"
+  ],
+  "out": "../../docs",
+  "includeVersion": true,
+  "intentionallyNotExported": ["QueryParamType"],
+}


### PR DESCRIPTION
# Purpose

Typedoc was only documenting the top-level exports. This should enable it to document all of the modbules and tweak a few other settings.