### PR TITLE
Update error detection for Projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Unreleased
 
+- Update error detection for Projects (See #450)
+
 ### 3.2.0
 
 - Support Journal Entry (See #401)

--- a/packages/api/src/models/Error.ts
+++ b/packages/api/src/models/Error.ts
@@ -31,7 +31,7 @@ export default class APIClientError extends Error {
 export const isAccountingErrorResponse = ({ error, error_type: errorType, response }: any): any =>
 	error || errorType || response.errors
 
-export const isProjectErrorResponse = ({ error, error_type: errorType }: any): any => error || errorType
+export const isProjectErrorResponse = ({ error, error_type: errorType, message }: any): any => error || errorType || message
 
 export const isEventErrorResponse = ({ errno, message }: any): any => errno || message
 


### PR DESCRIPTION
# Purpose

When trying to retrieve a list of projects while using an expired token, a TypeError was thrown instead of a 401 Unauthorized error. This PR corrects that. 

Error Before Change:
`TypeError: Cannot destructure property 'total' of 'meta' as it is undefined. ...`
    
 Error After Change:
 `List Projects: UNAUTHORIZED ...` 

# Related Material

See Issue #450 