### PR TITLE
Update model transform methods 5

### DIFF
--- a/packages/api/__tests__/Role.test.ts
+++ b/packages/api/__tests__/Role.test.ts
@@ -1,36 +1,8 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { transformRoleJSON, transformRoleResponse } from '../src/models/Role'
+import { transformRoleResponse } from '../src/models/Role'
 
 describe('@freshbooks/api', () => {
 	describe('Role', () => {
-		test('Verify JSON -> model transform', async () => {
-			const json = `{
-                "id": 682608, 
-                "role": "admin", 
-                "systemid": 1953394, 
-                "userid": 1, 
-                "links": { 
-                    "destroy": "/service/auth/api/v1/users/role/682608" 
-                }, 
-                "accountid": "zDmNq",
-                "created_at": "2016-01-26T16:00:44Z"
-            }`
-			const model = transformRoleJSON(json)
-
-			expect(model).toEqual(
-				expect.objectContaining({
-					id: 682608,
-					role: 'admin',
-					systemId: 1953394,
-					userId: 1,
-					accountId: 'zDmNq',
-					createdAt: new Date('2016-01-26T16:00:44Z'),
-					links: expect.objectContaining({
-						destroy: '/service/auth/api/v1/users/role/682608',
-					}),
-				})
-			)
-		})
 		test('Verify parsed JSON -> model transform', async () => {
 			const data = {
 				id: 682608,

--- a/packages/api/__tests__/Role.test.ts
+++ b/packages/api/__tests__/Role.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { transformRoleResponse } from '../src/models/Role'
+import { transformRoleParsedResponse } from '../src/models/Role'
 
 describe('@freshbooks/api', () => {
 	describe('Role', () => {
@@ -15,7 +15,7 @@ describe('@freshbooks/api', () => {
 				accountid: 'zDmNq',
 				created_at: '2016-01-26T16:00:44Z',
 			}
-			const model = transformRoleResponse(data)
+			const model = transformRoleParsedResponse(data)
 
 			expect(model).toEqual(
 				expect.objectContaining({

--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -38,7 +38,7 @@ import {
 	transformOtherIncomeResponse,
 	transformOtherIncomeRequest,
 } from './models/OtherIncome'
-import { transformListServicesResponse, transformServiceResponse, transformServiceRequest } from './models/Service'
+import { transformServiceListResponse, transformServiceResponse, transformServiceRequest } from './models/Service'
 import { transformServiceRateResponse, transformServiceRateRequest } from './models/ServiceRate'
 import { transformShareLinkResponse } from './models/ShareLink'
 import { transformItemResponse, transformItemListResponse, transformItemRequest } from './models/Item'
@@ -950,7 +950,7 @@ export default class APIClient {
 				'GET',
 				`/comments/business/${businessId}/services`,
 				{
-					transformResponse: transformListServicesResponse,
+					transformResponse: transformServiceListResponse,
 				},
 				null,
 				'List Services'

--- a/packages/api/src/models/JournalEntryAccount.ts
+++ b/packages/api/src/models/JournalEntryAccount.ts
@@ -2,7 +2,7 @@
 import { DateFormat, transformDateResponse } from './Date'
 import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
 import Pagination from './Pagination'
-import SubAccount, { transformSubAccountResponse } from './SubAccount'
+import SubAccount, { transformSubAccountParsedResponse } from './SubAccount'
 
 export default interface JournalEntryAccount {
     accountName: string
@@ -48,6 +48,6 @@ export function transformJournalEntryAccountParsedResponse(account: any): Journa
         createdAt: account.created_at && transformDateResponse(account.created_at, DateFormat['YYYY-MM-DD hh:mm:ss']),
         currencyCode: account.currency_code,
         id: account.id,
-        subAccounts: account.sub_accounts && account.sub_accounts.map((subAccount: any): SubAccount => transformSubAccountResponse(subAccount)),
+        subAccounts: account.sub_accounts && account.sub_accounts.map((subAccount: any): SubAccount => transformSubAccountParsedResponse(subAccount)),
 	}
 }

--- a/packages/api/src/models/JournalEntryDetail.ts
+++ b/packages/api/src/models/JournalEntryDetail.ts
@@ -6,7 +6,7 @@ import JournalEntryAccount, { transformJournalEntryAccountParsedResponse } from 
 import Money, { transformMoneyParsedResponse } from './Money'
 import { Nullable } from './helpers'
 import Pagination from './Pagination'
-import SubAccount, { transformSubAccountResponse } from './SubAccount'
+import SubAccount, { transformSubAccountParsedResponse } from './SubAccount'
 
 export default interface JournalEntryDetail {
     account: JournalEntryAccount
@@ -57,7 +57,7 @@ export function transformJournalEntryDetailParsedResponse(detail: any): JournalE
         entry: detail.entry && transformEntryParsedResponse(detail.entry),
         id: detail.id,
         name: detail.name,
-        subAccount: detail.sub_account && transformSubAccountResponse(detail.sub_account),
+        subAccount: detail.sub_account && transformSubAccountParsedResponse(detail.sub_account),
         userEnteredDate: detail.user_entered_date && transformDateResponse(detail.user_entered_date, DateFormat['YYYY-MM-DD']),
 	}
 }

--- a/packages/api/src/models/OtherIncome.ts
+++ b/packages/api/src/models/OtherIncome.ts
@@ -2,7 +2,7 @@
 import Pagination from './Pagination'
 import { transformErrorResponse, isAccountingErrorResponse, ErrorResponse } from './Error'
 import Money, { transformMoneyParsedResponse } from './Money'
-import Tax, { transformTaxResponse, transformTaxRequest } from './Tax'
+import Tax, { transformTaxParsedResponse, transformTaxRequest } from './Tax'
 import { transformDateResponse, DateFormat, transformDateRequest } from './Date'
 
 enum CategoryName {
@@ -74,7 +74,7 @@ function transformOtherIncomeParsedResponse(otherIncome: any): OtherIncome {
 		note: otherIncome.note,
 		paymentType: otherIncome.payment_type,
 		source: otherIncome.source,
-		taxes: otherIncome.taxes && otherIncome.taxes.map((tax: any): Tax => transformTaxResponse(tax)),
+		taxes: otherIncome.taxes && otherIncome.taxes.map((tax: any): Tax => transformTaxParsedResponse(tax)),
 		updatedAt: otherIncome.updated_at && transformDateResponse(otherIncome.updated_at, DateFormat['YYYY-MM-DD hh:mm:ss']),
 		visState: otherIncome.vis_state,
 	}

--- a/packages/api/src/models/Project.ts
+++ b/packages/api/src/models/Project.ts
@@ -4,7 +4,7 @@ import Pagination from './Pagination'
 import { Nullable } from './helpers'
 import { transformDateResponse, DateFormat } from './Date'
 import ProjectGroup, { transformProjectGroupParsedResponse } from './ProjectGroup'
-import Service, { transformServiceData } from './Service'
+import Service, { transformServiceParsedResponse } from './Service'
 
 export enum ProjectType {
 	FixedPrice = 'fixed_price',
@@ -64,7 +64,6 @@ export function transformProjectResponse(data: string): Project | ErrorResponse 
 	return transformProjectParsedResponse(project)
 }
 
-
 export function transformProjectListResponse(data: string): { projects: Project[]; pages: Pagination } | ErrorResponse {
 	const response = JSON.parse(data)
 
@@ -106,7 +105,7 @@ function transformProjectParsedResponse(project: any): Project {
 		createdAt: transformDateResponse(project.created_at, DateFormat['YYYY-MM-DDThh:mm:ss']),
 		updatedAt: transformDateResponse(project.updated_at, DateFormat['YYYY-MM-DDThh:mm:ss']),
 		loggedDuration: project.logged_duration,
-		services: project.services && project.services.map(transformServiceData),
+		services: project.services && project.services.map(transformServiceParsedResponse),
 		billedAmount: project.billed_amount,
 		billedStatus: project.billed_status,
 		retainerId: project.retainer_id,
@@ -115,7 +114,6 @@ function transformProjectParsedResponse(project: any): Project {
 		group: project.group && transformProjectGroupParsedResponse(project.group),
 	}
 }
-
 
 export function transformProjectRequest(project: Project): string {
 	return JSON.stringify({

--- a/packages/api/src/models/Role.ts
+++ b/packages/api/src/models/Role.ts
@@ -19,29 +19,15 @@ export interface RoleResponse {
 	links: { [key: string]: string }
 }
 
-/**
- * Format a Role response object
- * @param data Role object
- * eg: { "id": 682608, "role": "admin", "systemid": 1953394, "userid": 1, "created_at": "2016-01-26T16:00:44Z", "links": { "destroy": "/service/auth/api/v1/users/role/682608" }, "accountid": "zDmNq"}
- * @returns Role object
- */
-export function transformRoleResponse({
-	id,
-	role,
-	systemid,
-	userid,
-	accountid,
-	created_at,
-	links,
-}: RoleResponse): Role {
+export function transformRoleResponse(role: RoleResponse): Role {
 	return {
-		id: id,
-		role,
-		systemId: systemid,
-		userId: userid,
-		accountId: accountid.toString(),
-		createdAt: new Date(created_at),
-		links,
+		id: role.id,
+		role: role.role,
+		systemId: role.systemid,
+		userId: role.userid,
+		accountId: role.accountid.toString(),
+		createdAt: new Date(role.created_at),
+		links: role.links,
 	}
 }
 

--- a/packages/api/src/models/Role.ts
+++ b/packages/api/src/models/Role.ts
@@ -30,24 +30,3 @@ export function transformRoleResponse(role: RoleResponse): Role {
 		links: role.links,
 	}
 }
-
-/**
- * Parse a JSON string to @Role object
- * @param json JSON string
- * eg: '{
- *         "id": 682608,
- *         "role": "admin",
- *         "systemid": 1953394,
- *         "userid": 1,
- *         "created_at": "2016-01-26T16:00:44Z",
- *         "links": {
- *              "destroy": "/service/auth/api/v1/users/role/682608"
- *         },
- *         "accountid": "zDmNq"
- *       }'
- * @returns Role object
- */
-export function transformRoleJSON(json: string): Role {
-	const response: RoleResponse = JSON.parse(json)
-	return transformRoleResponse(response)
-}

--- a/packages/api/src/models/Role.ts
+++ b/packages/api/src/models/Role.ts
@@ -19,7 +19,7 @@ export interface RoleResponse {
 	links: { [key: string]: string }
 }
 
-export function transformRoleResponse(role: RoleResponse): Role {
+export function transformRoleParsedResponse(role: RoleResponse): Role {
 	return {
 		id: role.id,
 		role: role.role,

--- a/packages/api/src/models/Service.ts
+++ b/packages/api/src/models/Service.ts
@@ -19,7 +19,7 @@ export function transformServiceResponse(data: string): Service | ErrorResponse 
 	}
 
 	const { service } = response
-	return transformServiceData(service)
+	return transformServiceParsedResponse(service)
 }
 
 export function transformServiceListResponse(data: string): { services: Service[]; pages: Pagination } | ErrorResponse {
@@ -33,7 +33,7 @@ export function transformServiceListResponse(data: string): { services: Service[
 	const { total, per_page, page, pages } = meta
 
 	return {
-		services: services.map((service: Service) => transformServiceData(service)),
+		services: services.map((service: Service) => transformServiceParsedResponse(service)),
 		pages: {
 			total,
 			size: per_page,
@@ -43,7 +43,7 @@ export function transformServiceListResponse(data: string): { services: Service[
 	}
 }
 
-export function transformServiceData(service: any): Service {
+export function transformServiceParsedResponse(service: any): Service {
 	return {
 		businessId: service.business_id,
 		id: service.id,

--- a/packages/api/src/models/Service.ts
+++ b/packages/api/src/models/Service.ts
@@ -14,11 +14,13 @@ export default interface Service {
 
 export function transformServiceResponse(data: string): Service | ErrorResponse {
 	const response = JSON.parse(data)
+
 	if (isProjectErrorResponse(response)) {
 		return transformErrorResponse(response)
 	}
 
 	const { service } = response
+	
 	return transformServiceParsedResponse(service)
 }
 

--- a/packages/api/src/models/Service.ts
+++ b/packages/api/src/models/Service.ts
@@ -54,10 +54,9 @@ export function transformServiceParsedResponse(service: any): Service {
 }
 
 export function transformServiceRequest(service: Service): string {
-	const request = JSON.stringify({
+	return JSON.stringify({
 		service: {
 			name: service.name,
 		},
 	})
-	return request
 }

--- a/packages/api/src/models/Service.ts
+++ b/packages/api/src/models/Service.ts
@@ -36,24 +36,24 @@ export function transformServiceResponse(data: string): Service | ErrorResponse 
 	return transformServiceData(service)
 }
 
-export function transformListServicesResponse(
-	data: string
-): { services: Service[]; pages: Pagination } | ErrorResponse {
+export function transformListServicesResponse(data: string): { services: Service[]; pages: Pagination } | ErrorResponse {
 	const response = JSON.parse(data)
 
 	if (isProjectErrorResponse(response)) {
 		return transformErrorResponse(response)
 	}
+
 	const { services, meta } = response
 	const { total, per_page, page, pages } = meta
+
 	return {
-		pages: {
-			page,
-			pages,
-			size: per_page,
-			total,
-		},
 		services: services.map((service: Service) => transformServiceData(service)),
+		pages: {
+			total,
+			size: per_page,
+			pages,
+			page,
+		},
 	}
 }
 

--- a/packages/api/src/models/Service.ts
+++ b/packages/api/src/models/Service.ts
@@ -36,7 +36,7 @@ export function transformServiceResponse(data: string): Service | ErrorResponse 
 	return transformServiceData(service)
 }
 
-export function transformListServicesResponse(data: string): { services: Service[]; pages: Pagination } | ErrorResponse {
+export function transformServiceListResponse(data: string): { services: Service[]; pages: Pagination } | ErrorResponse {
 	const response = JSON.parse(data)
 
 	if (isProjectErrorResponse(response)) {

--- a/packages/api/src/models/Service.ts
+++ b/packages/api/src/models/Service.ts
@@ -11,21 +11,7 @@ export default interface Service {
 	billable?: boolean
 	visState?: VisState
 }
-export function transformServiceData({
-	business_id: businessId,
-	id: id,
-	name: name,
-	billable: billable,
-	vis_state: visState,
-}: any): Service {
-	return {
-		businessId,
-		id,
-		name,
-		billable,
-		visState,
-	}
-}
+
 export function transformServiceResponse(data: string): Service | ErrorResponse {
 	const response = JSON.parse(data)
 	if (isProjectErrorResponse(response)) {
@@ -54,6 +40,16 @@ export function transformServiceListResponse(data: string): { services: Service[
 			pages,
 			page,
 		},
+	}
+}
+
+export function transformServiceData(service: any): Service {
+	return {
+		businessId: service.business_id,
+		id: service.id,
+		name: service.name,
+		billable: service.billable,
+		visState: service.vis_state,
 	}
 }
 

--- a/packages/api/src/models/ServiceRate.ts
+++ b/packages/api/src/models/ServiceRate.ts
@@ -9,11 +9,13 @@ export default interface ServiceRate {
 
 export function transformServiceRateResponse(data: string): ServiceRate | ErrorResponse {
 	const response = JSON.parse(data)
+
 	if (isProjectErrorResponse(response)) {
 		return transformErrorResponse(response)
 	}
 
 	const { service_rate } = response
+	
 	return transformServiceRateParsedResponse(service_rate)
 }
 

--- a/packages/api/src/models/ServiceRate.ts
+++ b/packages/api/src/models/ServiceRate.ts
@@ -15,7 +15,7 @@ export function transformServiceRateResponse(data: string): ServiceRate | ErrorR
 	}
 
 	const { service_rate } = response
-	
+
 	return transformServiceRateParsedResponse(service_rate)
 }
 
@@ -27,11 +27,10 @@ function transformServiceRateParsedResponse(serviceRate: any): ServiceRate {
 	}
 }
 
-export function transformServiceRateRequest(service_rate: ServiceRate): string {
-	const request = JSON.stringify({
+export function transformServiceRateRequest(serviceRate: ServiceRate): string {
+	return JSON.stringify({
 		service_rate: {
-			rate: service_rate.rate,
+			rate: serviceRate.rate,
 		},
 	})
-	return request
 }

--- a/packages/api/src/models/ServiceRate.ts
+++ b/packages/api/src/models/ServiceRate.ts
@@ -6,13 +6,7 @@ export default interface ServiceRate {
 	businessId?: number
 	serviceId?: number
 }
-function transformServiceRateData({ rate: rate, business_id: businessId, service_id: serviceId }: any): ServiceRate {
-	return {
-		rate,
-		businessId,
-		serviceId,
-	}
-}
+
 export function transformServiceRateResponse(data: string): ServiceRate | ErrorResponse {
 	const response = JSON.parse(data)
 	if (isProjectErrorResponse(response)) {
@@ -21,6 +15,14 @@ export function transformServiceRateResponse(data: string): ServiceRate | ErrorR
 
 	const { service_rate } = response
 	return transformServiceRateData(service_rate)
+}
+
+function transformServiceRateData(serviceRate: any): ServiceRate {
+	return {
+		rate: serviceRate.rate,
+		businessId: serviceRate.business_id,
+		serviceId: serviceRate.service_id,
+	}
 }
 
 export function transformServiceRateRequest(service_rate: ServiceRate): string {

--- a/packages/api/src/models/ServiceRate.ts
+++ b/packages/api/src/models/ServiceRate.ts
@@ -14,10 +14,10 @@ export function transformServiceRateResponse(data: string): ServiceRate | ErrorR
 	}
 
 	const { service_rate } = response
-	return transformServiceRateData(service_rate)
+	return transformServiceRateParsedResponse(service_rate)
 }
 
-function transformServiceRateData(serviceRate: any): ServiceRate {
+function transformServiceRateParsedResponse(serviceRate: any): ServiceRate {
 	return {
 		rate: serviceRate.rate,
 		businessId: serviceRate.business_id,

--- a/packages/api/src/models/ShareLink.ts
+++ b/packages/api/src/models/ShareLink.ts
@@ -24,7 +24,7 @@ export function transformShareLinkResponse(data: string): ShareLink | ErrorRespo
 function transformShareLinkParsedResponse(link: any): ShareLink {
 	return {
 		resourceId: link.resourceid,
-		clientId: link.client_id,
+		clientId: link.clientid,
 		resourceType: link.resource_type,
 		shareLink: link.share_link,
 		shareMethod: link.share_method,

--- a/packages/api/src/models/ShareLink.ts
+++ b/packages/api/src/models/ShareLink.ts
@@ -18,10 +18,10 @@ export function transformShareLinkResponse(data: string): ShareLink | ErrorRespo
 
 	const { share_link } = response.response.result
 
-	return transformShareLinkData(share_link)
+	return transformShareLinkParsedResponse(share_link)
 }
 
-function transformShareLinkData(link: any): ShareLink {
+function transformShareLinkParsedResponse(link: any): ShareLink {
 	return {
 		resourceId: link.resourceid,
 		clientId: link.client_id,

--- a/packages/api/src/models/ShareLink.ts
+++ b/packages/api/src/models/ShareLink.ts
@@ -32,10 +32,7 @@ export function transformShareLinkResponse(data: string): ShareLink | ErrorRespo
 		return transformErrorResponse(response)
 	}
 
-	const {
-		response: { result },
-	} = response
-	const { share_link } = result
+	const { share_link } = response.response.result
+
 	return transformShareLinkData(share_link)
 }
-

--- a/packages/api/src/models/ShareLink.ts
+++ b/packages/api/src/models/ShareLink.ts
@@ -9,22 +9,6 @@ export default interface ShareLink {
 	shareMethod: string
 }
 
-function transformShareLinkData({
-	resourceid: resourceId,
-	clientid: clientId,
-	resource_type: resourceType,
-	share_link: shareLink,
-	share_method: shareMethod,
-}: any): ShareLink {
-	return {
-		resourceId,
-		clientId,
-		resourceType,
-		shareLink,
-		shareMethod,
-	}
-}
-
 export function transformShareLinkResponse(data: string): ShareLink | ErrorResponse {
 	const response = JSON.parse(data)
 
@@ -35,4 +19,14 @@ export function transformShareLinkResponse(data: string): ShareLink | ErrorRespo
 	const { share_link } = response.response.result
 
 	return transformShareLinkData(share_link)
+}
+
+function transformShareLinkData(link: any): ShareLink {
+	return {
+		resourceId: link.resourceid,
+		clientId: link.client_id,
+		resourceType: link.resource_type,
+		shareLink: link.share_link,
+		shareMethod: link.share_method,
+	}
 }

--- a/packages/api/src/models/SubAccount.ts
+++ b/packages/api/src/models/SubAccount.ts
@@ -16,7 +16,7 @@ export default interface SubAccount {
     transactionPosted?: boolean
 }
 
-export function transformSubAccountResponse(account: any): SubAccount {
+export function transformSubAccountParsedResponse(account: any): SubAccount {
     return {
         accountSubName: account.account_sub_name,
         accountSubNumber: account.account_sub_number,

--- a/packages/api/src/models/Tasks.ts
+++ b/packages/api/src/models/Tasks.ts
@@ -18,21 +18,6 @@ export default interface Tasks {
 	updated?: Date
 }
 
-export function transformTasksData(task: any): Tasks {
-	return {
-		id: task.id,
-		billable: task.billable,
-		description: task.description,
-		name: task.name,
-		rate: task.rate,
-		taskid: task.taskid,
-		tname: task.tname,
-		tdesc: task.tdesc,
-		visState: task.visState,
-		updated: task.updated,
-	}
-}
-
 export function transformTasksResponse(data: string): Tasks | ErrorResponse {
 	const response = JSON.parse(data)
 
@@ -42,7 +27,7 @@ export function transformTasksResponse(data: string): Tasks | ErrorResponse {
 
 	const { task } = response.response.result
 
-	return transformTasksData(task)
+	return transformTasksParsedResponse(task)
 }
 
 export function transformTasksListResponse(data: string): { tasks: Tasks[]; pages: Pagination } | ErrorResponse {
@@ -55,13 +40,28 @@ export function transformTasksListResponse(data: string): { tasks: Tasks[]; page
 	const { tasks, per_page, total, page, pages } = response.response.result
 
 	return {
-		tasks: tasks.map((task: Tasks) => transformTasksData(task)),
+		tasks: tasks.map((task: Tasks) => transformTasksParsedResponse(task)),
 		pages: {
 			total,
 			size: per_page,
 			pages,
 			page,
 		},
+	}
+}
+
+export function transformTasksParsedResponse(task: any): Tasks {
+	return {
+		id: task.id,
+		billable: task.billable,
+		description: task.description,
+		name: task.name,
+		rate: task.rate,
+		taskid: task.taskid,
+		tname: task.tname,
+		tdesc: task.tdesc,
+		visState: task.visState,
+		updated: task.updated,
 	}
 }
 

--- a/packages/api/src/models/Tasks.ts
+++ b/packages/api/src/models/Tasks.ts
@@ -44,29 +44,24 @@ export function transformTasksResponse(data: string): Tasks | ErrorResponse {
 
 	return transformTasksData(task)
 }
-/**
- * Parses JSON list response and converts to internal tasks list response
- * @param data representing JSON response
- * @returns tasks list response
- */
+
 export function transformTasksListResponse(data: string): { tasks: Tasks[]; pages: Pagination } | ErrorResponse {
 	const response = JSON.parse(data)
 
 	if (isAccountingErrorResponse(response)) {
 		return transformErrorResponse(response)
 	}
-	const {
-		response: { result },
-	} = response
-	const { tasks, per_page, total, page, pages } = result
+
+	const { tasks, per_page, total, page, pages } = response.response.result
+
 	return {
-		pages: {
-			page,
-			pages,
-			size: per_page,
-			total,
-		},
 		tasks: tasks.map((task: Tasks) => transformTasksData(task)),
+		pages: {
+			total,
+			size: per_page,
+			pages,
+			page,
+		},
 	}
 }
 

--- a/packages/api/src/models/Tasks.ts
+++ b/packages/api/src/models/Tasks.ts
@@ -33,16 +33,15 @@ export function transformTasksData(task: any): Tasks {
 	}
 }
 
-export function transformTasksResponse(data: any): Tasks | ErrorResponse {
+export function transformTasksResponse(data: string): Tasks | ErrorResponse {
 	const response = JSON.parse(data)
+
 	if (isAccountingErrorResponse(response)) {
 		return transformErrorResponse(response)
 	}
 
-	const {
-		response: { result },
-	} = response
-	const { task } = result
+	const { task } = response.response.result
+
 	return transformTasksData(task)
 }
 /**

--- a/packages/api/src/models/Tax.ts
+++ b/packages/api/src/models/Tax.ts
@@ -15,9 +15,9 @@ export function transformTaxParsedResponse(tax: any): Tax {
 	}
 }
 
-export function transformTaxRequest({ amount, name }: Tax): any {
+export function transformTaxRequest(tax: Tax): any {
 	return {
-		amount,
-		name,
+		amount: tax.amount,
+		name: tax.name,
 	}
 }

--- a/packages/api/src/models/Tax.ts
+++ b/packages/api/src/models/Tax.ts
@@ -21,20 +21,6 @@ export function transformTaxResponse(tax: any): Tax {
 	}
 }
 
-/**
- * Parse a JSON string to @Tax object
- * @param json JSON string
- * eg: '{
- *          "amount": "1234.00",
- *          "code": "HST"
- *      }'
- * @returns Tax object
- */
-export function transformtaxJSON(json: string): Tax {
-	const response: TaxResponse = JSON.parse(json)
-	return transformTaxResponse(response)
-}
-
 export function transformTaxRequest({ amount, name }: Tax): any {
 	return {
 		amount,

--- a/packages/api/src/models/Tax.ts
+++ b/packages/api/src/models/Tax.ts
@@ -3,11 +3,6 @@ export default interface Tax {
 	name?: string
 }
 
-export interface TaxResponse {
-	amount: string
-	name: string
-}
-
 export function transformTaxParsedResponse(tax: any): Tax {
 	return {
 		amount: tax.amount,

--- a/packages/api/src/models/Tax.ts
+++ b/packages/api/src/models/Tax.ts
@@ -8,13 +8,7 @@ export interface TaxResponse {
 	name: string
 }
 
-/**
- * Format a Tax response object
- * @param tax Account business object
- * eg: { "amount": "1234.00", "tax": "HST" }
- * @returns Tax object
- */
-export function transformTaxResponse(tax: any): Tax {
+export function transformTaxParsedResponse(tax: any): Tax {
 	return {
 		amount: tax.amount,
 		name: tax.name,

--- a/packages/api/src/models/TimeEntry.ts
+++ b/packages/api/src/models/TimeEntry.ts
@@ -64,29 +64,24 @@ export function transformTimeEntryResponse(data: string): TimeEntry | ErrorRespo
 	return transformTimeEntryData(time_entry)
 }
 
-/**
- * Parses JSON list response and converts to internal time_entry list response
- * @param data representing JSON response
- * @returns time_entry list response
- */
-export function transformTimeEntryListResponse(
-	data: string
-): { timeEntries: TimeEntry[]; pages: Pagination } | ErrorResponse {
+export function transformTimeEntryListResponse(data: string): { timeEntries: TimeEntry[]; pages: Pagination } | ErrorResponse {
 	const response = JSON.parse(data)
 
 	if (isProjectErrorResponse(response)) {
 		return transformErrorResponse(response)
 	}
+
 	const { time_entries, meta } = response
 	const { total, per_page, page, pages } = meta
+
 	return {
-		pages: {
-			page,
-			pages,
-			size: per_page,
-			total,
-		},
 		timeEntries: time_entries.map((time_entry: TimeEntry) => transformTimeEntryData(time_entry)),
+		pages: {
+			total,
+			size: per_page,
+			pages,
+			page,
+		},	
 	}
 }
 

--- a/packages/api/src/models/TimeEntry.ts
+++ b/packages/api/src/models/TimeEntry.ts
@@ -3,7 +3,7 @@ import { ErrorResponse, isProjectErrorResponse, transformErrorResponse } from '.
 import Pagination from './Pagination'
 import { Nullable } from './helpers'
 import { transformDateResponse, DateFormat } from './Date'
-import Timer, { transformTimerResponse } from './Timer'
+import Timer, { transformTimerParsedResponse } from './Timer'
 
 export default interface TimeEntry {
 	id?: number
@@ -81,7 +81,7 @@ function transformTimeEntryParsedResponse(timeEntry: any): TimeEntry {
 		internal: timeEntry.internal,
 		retainerId: timeEntry.retainer_id,
 		duration: timeEntry.duration,
-		timer: timeEntry.timer && transformTimerResponse(timeEntry.timer),
+		timer: timeEntry.timer && transformTimerParsedResponse(timeEntry.timer),
 	}
 }
 

--- a/packages/api/src/models/TimeEntry.ts
+++ b/packages/api/src/models/TimeEntry.ts
@@ -53,18 +53,14 @@ function transformTimeEntryData(timeEntry: any): TimeEntry {
 	}
 }
 
-/**
- * Parses JSON response and converts to @TimeEntry model
- * @param data representing JSON response
- * @returns @TimeEntry | @Error
- */
-export function transformTimeEntryResponse(data: any): TimeEntry | ErrorResponse {
+export function transformTimeEntryResponse(data: string): TimeEntry | ErrorResponse {
 	const response = JSON.parse(data)
 
 	if (isProjectErrorResponse(response)) {
 		return transformErrorResponse(response)
 	}
 	const { time_entry } = response
+
 	return transformTimeEntryData(time_entry)
 }
 

--- a/packages/api/src/models/TimeEntry.ts
+++ b/packages/api/src/models/TimeEntry.ts
@@ -85,13 +85,8 @@ function transformTimeEntryParsedResponse(timeEntry: any): TimeEntry {
 	}
 }
 
-/**
- * Converts @TimeEntry object into JSON string
- * @param timeEntry @TimeEntry object
- * @returns JSON string representing timeEntry request
- */
 export function transformTimeEntryRequest(timeEntry: TimeEntry): string {
-	const model = {
+	return JSON.stringify({
 		time_entry: {
 			id: timeEntry.id,
 			identity_id: timeEntry.identityId,
@@ -112,6 +107,5 @@ export function transformTimeEntryRequest(timeEntry: TimeEntry): string {
 			retainer_id: timeEntry.retainerId,
 			duration: timeEntry.duration,
 		},
-	}
-	return JSON.stringify(model)
+	})
 }

--- a/packages/api/src/models/TimeEntry.ts
+++ b/packages/api/src/models/TimeEntry.ts
@@ -28,7 +28,39 @@ export default interface TimeEntry {
 	timer?: Nullable<Timer>
 }
 
-function transformTimeEntryData(timeEntry: any): TimeEntry {
+export function transformTimeEntryResponse(data: string): TimeEntry | ErrorResponse {
+	const response = JSON.parse(data)
+
+	if (isProjectErrorResponse(response)) {
+		return transformErrorResponse(response)
+	}
+	const { time_entry } = response
+
+	return transformTimeEntryParsedResponse(time_entry)
+}
+
+export function transformTimeEntryListResponse(data: string): { timeEntries: TimeEntry[]; pages: Pagination } | ErrorResponse {
+	const response = JSON.parse(data)
+
+	if (isProjectErrorResponse(response)) {
+		return transformErrorResponse(response)
+	}
+
+	const { time_entries, meta } = response
+	const { total, per_page, page, pages } = meta
+
+	return {
+		timeEntries: time_entries.map((time_entry: TimeEntry) => transformTimeEntryParsedResponse(time_entry)),
+		pages: {
+			total,
+			size: per_page,
+			pages,
+			page,
+		},	
+	}
+}
+
+function transformTimeEntryParsedResponse(timeEntry: any): TimeEntry {
 	return {
 		id: timeEntry.id,
 		identityId: timeEntry.identity_id,
@@ -50,38 +82,6 @@ function transformTimeEntryData(timeEntry: any): TimeEntry {
 		retainerId: timeEntry.retainer_id,
 		duration: timeEntry.duration,
 		timer: timeEntry.timer && transformTimerResponse(timeEntry.timer),
-	}
-}
-
-export function transformTimeEntryResponse(data: string): TimeEntry | ErrorResponse {
-	const response = JSON.parse(data)
-
-	if (isProjectErrorResponse(response)) {
-		return transformErrorResponse(response)
-	}
-	const { time_entry } = response
-
-	return transformTimeEntryData(time_entry)
-}
-
-export function transformTimeEntryListResponse(data: string): { timeEntries: TimeEntry[]; pages: Pagination } | ErrorResponse {
-	const response = JSON.parse(data)
-
-	if (isProjectErrorResponse(response)) {
-		return transformErrorResponse(response)
-	}
-
-	const { time_entries, meta } = response
-	const { total, per_page, page, pages } = meta
-
-	return {
-		timeEntries: time_entries.map((time_entry: TimeEntry) => transformTimeEntryData(time_entry)),
-		pages: {
-			total,
-			size: per_page,
-			pages,
-			page,
-		},	
 	}
 }
 

--- a/packages/api/src/models/Timer.ts
+++ b/packages/api/src/models/Timer.ts
@@ -6,12 +6,7 @@ export default interface Timer {
 	isRunning?: Nullable<boolean>
 }
 
-/**
- * Convert a Timer response object
- *
- * @param timer Account business object
- */
-export function transformTimerResponse(timer: any): Timer {
+export function transformTimerParsedResponse(timer: any): Timer {
 	return {
 		id: timer.id,
 		isRunning: timer.is_running,

--- a/packages/api/src/models/User.ts
+++ b/packages/api/src/models/User.ts
@@ -32,34 +32,25 @@ export function transformUserResponse(data: string): User | ErrorResponse {
 		return transformErrorResponse(response)
 	}
 
-	const {
-		id,
-		first_name,
-		last_name,
-		email,
-		phone_numbers: phoneNumbers = [],
-		addresses = [],
-		permissions = {},
-		subscription_statuses: subscriptionStatuses,
-		business_memberships: businessMemberships = [],
-		roles = [],
-		profession,
-		groups = [],
-		links = {},
-	} = response.response
+	const user = response.response
+
+	return transformUserParsedResponse(user)
+}
+
+export function transformUserParsedResponse(user: any): User {
 	return {
-		id: id.toString(), // store ids as string
-		firstName: first_name,
-		lastName: last_name,
-		email,
-		phoneNumbers: phoneNumbers.map(transformPhoneNumberParsedResponse),
-		permissions,
-		subscriptionStatuses,
-		businessMemberships: businessMemberships.map(transformBusinessMembershipParsedResponse),
-		roles: roles.map(transformRoleParsedResponse),
-		addresses: addresses.filter((address: Nullable<AddressResponse>) => address !== null).map(transformAddressParsedResponse),
-		profession: profession && transformProfessionParsedResponse(profession),
-		groups: groups.map(transformGroupParsedResponse),
-		links,
+		id: user.id.toString(),
+		firstName: user.first_name,
+		lastName: user.last_name,
+		email: user.email,
+		phoneNumbers: user.phone_numbers && user.phone_numbers.map(transformPhoneNumberParsedResponse),
+		permissions: user.permissions,
+		subscriptionStatuses: user.subscription_statuses,
+		businessMemberships: user.business_memberships && user.business_memberships.map(transformBusinessMembershipParsedResponse),
+		roles: user.roles && user.roles.map(transformRoleParsedResponse),
+		addresses: user.addresses && user.addresses.filter((address: Nullable<AddressResponse>) => address !== null).map(transformAddressParsedResponse),
+		profession: user.profession && transformProfessionParsedResponse(user.profession),
+		groups: user.groups && user.groups.map(transformGroupParsedResponse),
+		links: user.links,
 	}
 }

--- a/packages/api/src/models/User.ts
+++ b/packages/api/src/models/User.ts
@@ -3,7 +3,7 @@ import { isAccountingErrorResponse, transformErrorResponse, ErrorResponse } from
 import PhoneNumber, { transformPhoneNumberParsedResponse } from './PhoneNumber'
 import Address, { transformAddressParsedResponse, AddressResponse } from './Address'
 import BusinessMembership, { transformBusinessMembershipParsedResponse } from './BusinessMembership'
-import Role, { transformRoleResponse } from './Role'
+import Role, { transformRoleParsedResponse } from './Role'
 import Profession, { transformProfessionParsedResponse } from './Profession'
 import Group, { transformGroupParsedResponse } from './Group'
 import Permission from './Permission'
@@ -56,7 +56,7 @@ export function transformUserResponse(data: string): User | ErrorResponse {
 		permissions,
 		subscriptionStatuses,
 		businessMemberships: businessMemberships.map(transformBusinessMembershipParsedResponse),
-		roles: roles.map(transformRoleResponse),
+		roles: roles.map(transformRoleParsedResponse),
 		addresses: addresses.filter((address: Nullable<AddressResponse>) => address !== null).map(transformAddressParsedResponse),
 		profession: profession && transformProfessionParsedResponse(profession),
 		groups: groups.map(transformGroupParsedResponse),


### PR DESCRIPTION
# Purpose

This PR is the fifth of several to update the transform methods within the model files.
This PR handles models with names that begin with R --> Z, inclusive.

- Refactor transform response methods
- Refactor transform request methods
- Rename transform methods
- Delete unused methods

To make review easier, this branch should be rebased after the previous PRs have been merged to main.

## Previous PRs
PR-1: #476 
~~PR-2: #479~~ [closed]
PR-2: #485  
PR-3: #480 
PR-4: #481 