### PR TITLE
Rename transform request methods

### DIFF
--- a/packages/api/src/models/BillLines.ts
+++ b/packages/api/src/models/BillLines.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import Money, { transformMoneyRequest, transformMoneyParsedResponse } from './Money'
+import Money, { transformMoneyParsedRequest, transformMoneyParsedResponse } from './Money'
 
 export default interface BillLines {
 	categoryId?: number
@@ -46,7 +46,7 @@ export function transformBillLinesParsedRequest(line: BillLines): any {
 		categoryid: line.categoryId,
 		description: line.description,
 		quantity: line.quantity,
-		unit_cost: line.unitCost && transformMoneyRequest(line.unitCost),
+		unit_cost: line.unitCost && transformMoneyParsedRequest(line.unitCost),
 		tax_name1: line.taxName1,
 		tax_name2: line.taxName2,
 		tax_percent1: line.taxPercent1,

--- a/packages/api/src/models/BillLines.ts
+++ b/packages/api/src/models/BillLines.ts
@@ -41,7 +41,7 @@ export function transformBillLinesParsedResponse(line: any): BillLines {
 	}
 }
 
-export function transformBillLinesRequest(line: BillLines): any {
+export function transformBillLinesParsedRequest(line: BillLines): any {
 	return {
 		categoryid: line.categoryId,
 		description: line.description,

--- a/packages/api/src/models/BillPayments.ts
+++ b/packages/api/src/models/BillPayments.ts
@@ -2,7 +2,7 @@
 import Pagination from './Pagination'
 import { DateFormat, transformDateRequest, transformDateResponse } from './Date'
 import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
-import Money, { transformMoneyRequest, transformMoneyParsedResponse } from './Money'
+import Money, { transformMoneyParsedRequest, transformMoneyParsedResponse } from './Money'
 import VisState from './VisState'
 
 enum PaymentType {
@@ -82,7 +82,7 @@ export function transformBillPaymentsRequest(payment: BillPayments): string {
 	return JSON.stringify({
 		bill_payment: {
 			id: payment.id,
-			amount: payment.amount && transformMoneyRequest(payment.amount),
+			amount: payment.amount && transformMoneyParsedRequest(payment.amount),
 			billid: payment.billId,
 			paid_date: payment.paidDate && transformDateRequest(payment.paidDate),
 			payment_type: payment.paymentType,

--- a/packages/api/src/models/BillVendorTax.ts
+++ b/packages/api/src/models/BillVendorTax.ts
@@ -27,7 +27,7 @@ export function transformBillVendorTaxParsedResponse(tax: any): BillVendorTax {
 	}
 }
 
-export function transformBillVendorTaxRequest(tax: BillVendorTax): any {
+export function transformBillVendorTaxParsedRequest(tax: BillVendorTax): any {
 	return {
 		vendorid: tax.vendorId,
 		tax_id: tax.taxId,

--- a/packages/api/src/models/BillVendors.ts
+++ b/packages/api/src/models/BillVendors.ts
@@ -4,7 +4,7 @@ import Money, { MoneyResponse, transformMoneyParsedResponse } from './Money'
 import { transformDateResponse, DateFormat } from './Date'
 import VisState from './VisState'
 import Pagination from './Pagination'
-import BillVendorTax, { transformBillVendorTaxRequest, transformBillVendorTaxParsedResponse } from './BillVendorTax'
+import BillVendorTax, { transformBillVendorTaxParsedRequest, transformBillVendorTaxParsedResponse } from './BillVendorTax'
 
 export default interface BillVendors {
 	accountNumber?: string
@@ -120,7 +120,7 @@ export function transformBillVendorsRequest(vendor: BillVendors): string {
 			street2: vendor.street2,
 			tax_defaults:
 				vendor.taxDefaults &&
-				vendor.taxDefaults.map((tax: BillVendorTax): any => transformBillVendorTaxRequest(tax)),
+				vendor.taxDefaults.map((tax: BillVendorTax): any => transformBillVendorTaxParsedRequest(tax)),
 			vendorid: vendor.vendorId,
 			vis_state: vendor.visState,
 			website: vendor.website,

--- a/packages/api/src/models/Bills.ts
+++ b/packages/api/src/models/Bills.ts
@@ -5,7 +5,7 @@ import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from
 import Pagination from './Pagination'
 import BillPayments, { transformBillPaymentsParsedResponse } from './BillPayments'
 import VisState from './VisState'
-import BillLines, { transformBillLinesRequest, transformBillLinesParsedResponse } from './BillLines'
+import BillLines, { transformBillLinesParsedRequest, transformBillLinesParsedResponse } from './BillLines'
 import BillVendors, { transformBillVendorsParsedResponse } from './BillVendors'
 
 enum BillStatus {
@@ -117,7 +117,7 @@ export function transformBillsRequest(bill: Bills): string {
 			due_offset_days: bill.dueOffsetDays,
 			issue_date: bill.issueDate && transformDateRequest(bill.issueDate),
 			language: bill.language,
-			lines: bill.lines && bill.lines.map((line: any): BillLines => transformBillLinesRequest(line)),
+			lines: bill.lines && bill.lines.map((line: any): BillLines => transformBillLinesParsedRequest(line)),
 			vendorid: bill.vendorId,
 			vis_state: bill.visState,
 		},

--- a/packages/api/src/models/CreditNote.ts
+++ b/packages/api/src/models/CreditNote.ts
@@ -1,6 +1,6 @@
 import Pagination from './Pagination'
 import { transformErrorResponse, isAccountingErrorResponse, ErrorResponse } from './Error'
-import Money, { transformMoneyRequest, transformMoneyParsedResponse } from './Money'
+import Money, { transformMoneyParsedRequest, transformMoneyParsedResponse } from './Money'
 import { Nullable } from './helpers'
 import VisState from './VisState'
 import Line, { transformLineParsedRequest, transformLineParsedResponse } from './Line'
@@ -154,7 +154,7 @@ export function transformCreditNoteRequest(creditNote: CreditNote): string {
     return JSON.stringify({
         credit_notes: {
             accounting_systemid: creditNote.accountingSystemId,
-            amount: creditNote.amount && transformMoneyRequest(creditNote.amount),
+            amount: creditNote.amount && transformMoneyParsedRequest(creditNote.amount),
             city: creditNote.city,
             clientid: creditNote.clientId,
             country: creditNote.country,
@@ -177,7 +177,7 @@ export function transformCreditNoteRequest(creditNote: CreditNote): string {
             lines: creditNote.lines && creditNote.lines.map((line: Line): any => transformLineParsedRequest(line)),
             notes: creditNote.notes,
             organization: creditNote.organization,
-            paid: creditNote.paid && transformMoneyRequest(creditNote.paid),
+            paid: creditNote.paid && transformMoneyParsedRequest(creditNote.paid),
             payment_status: creditNote.paymentStatus,
             payment_type: creditNote.paymentType,
             province: creditNote.province,

--- a/packages/api/src/models/CreditNote.ts
+++ b/packages/api/src/models/CreditNote.ts
@@ -3,7 +3,7 @@ import { transformErrorResponse, isAccountingErrorResponse, ErrorResponse } from
 import Money, { transformMoneyRequest, transformMoneyParsedResponse } from './Money'
 import { Nullable } from './helpers'
 import VisState from './VisState'
-import Line, { transformLineRequest, transformLineParsedResponse } from './Line'
+import Line, { transformLineParsedRequest, transformLineParsedResponse } from './Line'
 import { transformDateResponse, DateFormat, transformDateRequest } from './Date'
 
 enum CreditType {
@@ -174,7 +174,7 @@ export function transformCreditNoteRequest(creditNote: CreditNote): string {
             language: creditNote.language,
             last_order_status: creditNote.lastOrderStatus,
             lname: creditNote.lName,
-            lines: creditNote.lines && creditNote.lines.map((line: Line): any => transformLineRequest(line)),
+            lines: creditNote.lines && creditNote.lines.map((line: Line): any => transformLineParsedRequest(line)),
             notes: creditNote.notes,
             organization: creditNote.organization,
             paid: creditNote.paid && transformMoneyRequest(creditNote.paid),

--- a/packages/api/src/models/Detail.ts
+++ b/packages/api/src/models/Detail.ts
@@ -30,7 +30,7 @@ export function transformDetailParsedResponse(detail: any): Detail {
 
 }
 
-export function transformDetailRequest(detail: Detail): any {
+export function transformDetailParsedRequest(detail: Detail): any {
     return {
         credit: detail.credit,
         debit: detail.debit,

--- a/packages/api/src/models/Expense.ts
+++ b/packages/api/src/models/Expense.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import Money, { transformMoneyParsedResponse, transformMoneyRequest } from './Money'
+import Money, { transformMoneyParsedRequest, transformMoneyParsedResponse } from './Money'
 import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
 import { Nullable, transformIdResponse } from './helpers'
 import Pagination from './Pagination'
@@ -137,8 +137,8 @@ export function transformExpenseRequest(expense: Expense): string {
 			transactionid: expense.transactionId,
 			invoiceid: expense.invoiceId,
 			id: expense.id,
-			taxAmount2: expense.taxAmount2 && transformMoneyRequest(expense.taxAmount2),
-			taxAmount1: expense.taxAmount1 && transformMoneyRequest(expense.taxAmount1),
+			taxAmount2: expense.taxAmount2 && transformMoneyParsedRequest(expense.taxAmount2),
+			taxAmount1: expense.taxAmount1 && transformMoneyParsedRequest(expense.taxAmount1),
 			vis_state: expense.visState,
 			status: expense.status,
 			bank_name: expense.bankName,
@@ -149,7 +149,7 @@ export function transformExpenseRequest(expense: Expense): string {
 			has_receipt: expense.hasReceipt,
 			notes: expense.notes,
 			ext_invoiceid: expense.extInvoiceId,
-			amount: expense.amount && transformMoneyRequest(expense.amount),
+			amount: expense.amount && transformMoneyParsedRequest(expense.amount),
 			expenseid: expense.expenseId,
 			compounded_tax: expense.compoundedTax,
 			accountid: expense.accountId,

--- a/packages/api/src/models/Invoices.ts
+++ b/packages/api/src/models/Invoices.ts
@@ -4,7 +4,7 @@ import { transformErrorResponse, isAccountingErrorResponse, ErrorResponse } from
 import Money, { transformMoneyParsedResponse } from './Money'
 import { Nullable } from './helpers'
 import VisState from './VisState'
-import Line, { transformLineRequest, transformLineParsedResponse } from './Line'
+import Line, { transformLineParsedRequest, transformLineParsedResponse } from './Line'
 import { transformDateResponse, DateFormat, transformDateRequest } from './Date'
 import Owner, { transformOwnerParsedResponse } from './Owner'
 
@@ -266,7 +266,7 @@ export function transformInvoiceRequest(invoice: Invoice): string {
 			invoice_number: invoice.invoiceNumber,
 			language: invoice.language,
 			last_order_status: invoice.lastOrderStatus,
-			lines: invoice.lines && invoice.lines.map((line: Line): any => transformLineRequest(line)),
+			lines: invoice.lines && invoice.lines.map((line: Line): any => transformLineParsedRequest(line)),
 			lname: invoice.lName,
 			notes: invoice.notes,
 			organization: invoice.organization,

--- a/packages/api/src/models/Item.ts
+++ b/packages/api/src/models/Item.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import Money, { transformMoneyParsedResponse, transformMoneyRequest } from './Money'
+import Money, { transformMoneyParsedRequest, transformMoneyParsedResponse } from './Money'
 import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
 import { Nullable } from './helpers'
 import Pagination from './Pagination'
@@ -82,7 +82,7 @@ export function transformItemRequest(item: Item): string {
 			qty: item.qty,
 			sku: item.sku,
 			inventory: item.inventory,
-			unit_cost: item.unitCost && transformMoneyRequest(item.unitCost),
+			unit_cost: item.unitCost && transformMoneyParsedRequest(item.unitCost),
 			tax1: item.tax1,
 			tax2: item.tax2,
 			vis_state: item.visState,

--- a/packages/api/src/models/JournalEntry.ts
+++ b/packages/api/src/models/JournalEntry.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { DateFormat, transformDateRequest, transformDateResponse } from './Date'
-import Detail, { transformDetailRequest, transformDetailParsedResponse } from './Detail'
+import Detail, { transformDetailParsedRequest, transformDetailParsedResponse } from './Detail'
 import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
 
 export default interface JournalEntry {
@@ -42,7 +42,7 @@ export function transformJournalEntryRequest(entry: JournalEntry): string {
         journal_entry: {
             currency_code: entry.currencyCode,
             description: entry.description,
-            details: entry.details && entry.details.map((detail: Detail): any => transformDetailRequest(detail)),
+            details: entry.details && entry.details.map((detail: Detail): any => transformDetailParsedRequest(detail)),
             name: entry.name,
             user_entered_date: entry.userEnteredDate && transformDateRequest(entry.userEnteredDate),
         }

--- a/packages/api/src/models/Line.ts
+++ b/packages/api/src/models/Line.ts
@@ -58,7 +58,7 @@ export function transformLineParsedResponse(line: any): Line {
 	}
 }
 
-export function transformLineRequest(line: Line): any {
+export function transformLineParsedRequest(line: Line): any {
 	return {
 		compounded_tax: line.compoundedTax,
 		type: line.type,

--- a/packages/api/src/models/Money.ts
+++ b/packages/api/src/models/Money.ts
@@ -15,7 +15,7 @@ export function transformMoneyParsedResponse(money: MoneyResponse): Money {
 	}
 }
 
-export function transformMoneyRequest(money: Money = {}): any {
+export function transformMoneyParsedRequest(money: Money = {}): any {
 	return {
 		amount: money.amount,
 		code: money.code,

--- a/packages/api/src/models/OtherIncome.ts
+++ b/packages/api/src/models/OtherIncome.ts
@@ -81,7 +81,7 @@ function transformOtherIncomeParsedResponse(income: any): OtherIncome {
 }
 
 export function transformOtherIncomeRequest(income: OtherIncome): string {
-	const request = JSON.stringify({
+	return JSON.stringify({
 		other_income: {
 			amount: income.amount,
 			category_name: income.categoryName,
@@ -92,5 +92,4 @@ export function transformOtherIncomeRequest(income: OtherIncome): string {
 			taxes: income.taxes && income.taxes.map((tax: Tax): any => transformTaxRequest(tax)),
 		},
 	})
-	return request
 }

--- a/packages/api/src/models/OtherIncome.ts
+++ b/packages/api/src/models/OtherIncome.ts
@@ -2,7 +2,7 @@
 import Pagination from './Pagination'
 import { transformErrorResponse, isAccountingErrorResponse, ErrorResponse } from './Error'
 import Money, { transformMoneyParsedResponse } from './Money'
-import Tax, { transformTaxParsedResponse, transformTaxRequest } from './Tax'
+import Tax, { transformTaxParsedRequest, transformTaxParsedResponse } from './Tax'
 import { transformDateResponse, DateFormat, transformDateRequest } from './Date'
 
 enum CategoryName {
@@ -89,7 +89,7 @@ export function transformOtherIncomeRequest(income: OtherIncome): string {
 			note: income.note,
 			payment_type: income.paymentType,
 			source: income.source,
-			taxes: income.taxes && income.taxes.map((tax: Tax): any => transformTaxRequest(tax)),
+			taxes: income.taxes && income.taxes.map((tax: Tax): any => transformTaxParsedRequest(tax)),
 		},
 	})
 }

--- a/packages/api/src/models/Payment.ts
+++ b/packages/api/src/models/Payment.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import Money, { transformMoneyRequest, transformMoneyParsedResponse } from './Money'
+import Money, { transformMoneyParsedRequest, transformMoneyParsedResponse } from './Money'
 import VisState from './VisState'
 import { ErrorResponse, isAccountingErrorResponse, transformErrorResponse } from './Error'
 import Pagination from './Pagination'
@@ -102,7 +102,7 @@ function transformPaymentParsedResponse(payment: any): Payment {
 export function transformPaymentRequest(payment: Payment): string {
 	return JSON.stringify({
 		payment: {
-			amount: payment.amount && transformMoneyRequest(payment.amount),
+			amount: payment.amount && transformMoneyParsedRequest(payment.amount),
 			date: transformDateRequest(payment.date),
 			invoiceid: payment.invoiceId,
 			note: payment.note,
@@ -117,7 +117,7 @@ export function transformPaymentRequest(payment: Payment): string {
 export function transformPaymentUpdateRequest(payment: Payment): string {
 	return JSON.stringify({
 		payment: {
-			amount: payment.amount && transformMoneyRequest(payment.amount),
+			amount: payment.amount && transformMoneyParsedRequest(payment.amount),
 			date: payment.date && transformDateRequest(payment.date),
 			note: payment.note,
 			orderid: payment.orderId,

--- a/packages/api/src/models/Tasks.ts
+++ b/packages/api/src/models/Tasks.ts
@@ -3,7 +3,7 @@ import { isAccountingErrorResponse, transformErrorResponse, ErrorResponse } from
 import VisState from './VisState'
 import Pagination from './Pagination'
 import { Nullable } from './helpers'
-import Money, { transformMoneyRequest } from './Money'
+import Money, { transformMoneyParsedRequest } from './Money'
 
 export default interface Tasks {
 	id?: number
@@ -72,7 +72,7 @@ export function transformTasksRequest(task: Tasks): string {
 			billable: task.billable,
 			description: task.description,
 			name: task.name,
-			rate: task.rate && transformMoneyRequest(task.rate),
+			rate: task.rate && transformMoneyParsedRequest(task.rate),
 			taskid: task.taskid,
 			tname: task.tname,
 			tdesc: task.tdesc,

--- a/packages/api/src/models/Tax.ts
+++ b/packages/api/src/models/Tax.ts
@@ -10,7 +10,7 @@ export function transformTaxParsedResponse(tax: any): Tax {
 	}
 }
 
-export function transformTaxRequest(tax: Tax): any {
+export function transformTaxParsedRequest(tax: Tax): any {
 	return {
 		amount: tax.amount,
 		name: tax.name,


### PR DESCRIPTION
# Purpose

There are two flavours of model transform request methods:
1. One that includes stringifying the data; used by the APIClient 
2. One that _does not_ include stringifying the data; used internally

This PR renames the second flavour (internal) to create a distinction from the first flavour (APIClient):
`transformModelNameRequest` --> `transformModelNameParsedRequest`