### PR TITLE
🐛 Rewrite search query builder for non-accounting resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Unreleased
 
 - Add support for invoice send by email
+- Fix search queries for project-like and accounting report resources
 
 ### 3.2.2
 

--- a/packages/api/__tests__/Builders.test.ts
+++ b/packages/api/__tests__/Builders.test.ts
@@ -11,7 +11,7 @@ describe('@freshbooks/api', () => {
 
 			expect(builder.build()).toEqual(expected)
 		})
-		test('SearchQueryBuilder', () => {
+		test('SearchQueryBuilder - No parameter defaults to accountingLike', () => {
 			const result = new SearchQueryBuilder()
 				.like('address_like', '21 Peter Street')
 				.equals('userid', 1234)
@@ -24,6 +24,26 @@ describe('@freshbooks/api', () => {
 			const expected =
 				'search[address_like]=21 Peter Street&search[userid]=1234&search[userids][]=1&search[userids][]=2&search[userids][]=3&search[userids][]=4&search[updated_min]=2000-01-01&search[updated_max]=2015-12-15'
 
+			expect(result).toEqual(expected)
+		})
+		test('SearchQueryBuilder - AccountingLike', () => {
+			const result = new SearchQueryBuilder()
+				.like('address_like', '21 Peter Street')
+				.equals('userid', 1234)
+				.in('userids', [1, 2, 3, 4])
+				.between('updated', {
+					min: new Date('January 1, 2000'),
+					max: new Date('December 15, 2015'),
+				})
+				.build('AccountingResource')
+			const expected =
+				'search[address_like]=21 Peter Street&search[userid]=1234&search[userids][]=1&search[userids][]=2&search[userids][]=3&search[userids][]=4&search[updated_min]=2000-01-01&search[updated_max]=2015-12-15'
+
+			expect(result).toEqual(expected)
+		})
+		test('SearchQueryBuilder - ProjectLike', () => {
+			const result = new SearchQueryBuilder().equals('userid', 1234).build('ProjectResource')
+			const expected = 'userid=1234'
 			expect(result).toEqual(expected)
 		})
 		test('SearchQueryBuilder - Between options', () => {

--- a/packages/api/__tests__/PaymentsCollectedReport.test.ts
+++ b/packages/api/__tests__/PaymentsCollectedReport.test.ts
@@ -213,7 +213,11 @@ describe('@freshbooks/api', () => {
 				}`
 				const builder = new SearchQueryBuilder().equals('currency_code', 'CAD')
 				mock
-					.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/payments_collected?${builder.build()}`)
+					.onGet(
+						`/accounting/account/${ACCOUNT_ID}/reports/accounting/payments_collected?${builder.build(
+							'AccountingReportsResource'
+						)}`
+					)
 					.replyOnce(200, mockResponse)
 				const { data } = await client.reports.paymentsCollected(ACCOUNT_ID, [builder])
 				expect(data).toEqual(EXPECTED)

--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -478,7 +478,11 @@ export default class APIClient {
 	}
 
 	public readonly journalEntries = {
-		create: (journalEntry: JournalEntry, accountId: string, queryBuilders?: QueryBuilderType[]): Promise<Result<JournalEntry>> =>
+		create: (
+			journalEntry: JournalEntry,
+			accountId: string,
+			queryBuilders?: QueryBuilderType[]
+		): Promise<Result<JournalEntry>> =>
 			this.call(
 				'POST',
 				`/accounting/account/${accountId}/journal_entries/journal_entries${joinQueries(queryBuilders)}`,
@@ -666,7 +670,11 @@ export default class APIClient {
 	}
 
 	public readonly expenseCategories = {
-		single: (accountId: string, expenseCategoryId: string, queryBuilders?: QueryBuilderType[]): Promise<Result<ExpenseCategory>> =>
+		single: (
+			accountId: string,
+			expenseCategoryId: string,
+			queryBuilders?: QueryBuilderType[]
+		): Promise<Result<ExpenseCategory>> =>
 			this.call(
 				'GET',
 				`/accounting/account/${accountId}/expenses/categories/${expenseCategoryId}${joinQueries(queryBuilders)}`,
@@ -846,7 +854,7 @@ export default class APIClient {
 		): Promise<Result<{ projects: Project[]; pages: Pagination }>> =>
 			this.call(
 				'GET',
-				`/projects/business/${businessId}/projects${joinQueries(queryBuilders)}`,
+				`/projects/business/${businessId}/projects${joinQueries(queryBuilders, 'ProjectResource')}`,
 				{
 					transformResponse: transformProjectListResponse,
 				},
@@ -896,7 +904,7 @@ export default class APIClient {
 		): Promise<Result<{ timeEntries: TimeEntry[]; pages: Pagination }>> =>
 			this.call(
 				'GET',
-				`/timetracking/business/${businessId}/time_entries${joinQueries(queryBuilders)}`,
+				`/timetracking/business/${businessId}/time_entries${joinQueries(queryBuilders, 'ProjectResource')}`,
 				{
 					transformResponse: transformTimeEntryListResponse,
 				},
@@ -1373,7 +1381,10 @@ export default class APIClient {
 		): Promise<Result<{ callbacks: Callback[]; pages: Pagination }>> =>
 			this.call(
 				'GET',
-				`/accounting/account/${accountId}/reports/accounting/profitloss_entity${joinQueries(queryBuilders)}`,
+				`/accounting/account/${accountId}/reports/accounting/profitloss_entity${joinQueries(
+					queryBuilders,
+					'AccountingReportsResource'
+				)}`,
 				{
 					transformResponse: transformProfitLossReportResponse,
 				},
@@ -1386,7 +1397,10 @@ export default class APIClient {
 		): Promise<Result<{ callbacks: Callback[]; pages: Pagination }>> =>
 			this.call(
 				'GET',
-				`/accounting/account/${accountId}/reports/accounting/taxsummary${joinQueries(queryBuilders)}`,
+				`/accounting/account/${accountId}/reports/accounting/taxsummary${joinQueries(
+					queryBuilders,
+					'AccountingReportsResource'
+				)}`,
 				{
 					transformResponse: transformTaxSummaryReportResponse,
 				},
@@ -1399,7 +1413,10 @@ export default class APIClient {
 		): Promise<Result<{ callbacks: Callback[]; pages: Pagination }>> =>
 			this.call(
 				'GET',
-				`/accounting/account/${accountId}/reports/accounting/payments_collected${joinQueries(queryBuilders)}`,
+				`/accounting/account/${accountId}/reports/accounting/payments_collected${joinQueries(
+					queryBuilders,
+					'AccountingReportsResource'
+				)}`,
 				{
 					transformResponse: transformPaymentsCollectedReportResponse,
 				},

--- a/packages/api/src/models/builders/IncludesQueryBuilder.ts
+++ b/packages/api/src/models/builders/IncludesQueryBuilder.ts
@@ -24,7 +24,7 @@ export class IncludesQueryBuilder {
 		return this
 	}
 
-	build(): string {
+	build(resourceType?: string): string {
 		return buildQueryString(this.queryParams)
 	}
 }

--- a/packages/api/src/models/builders/PaginationQueryBuilder.ts
+++ b/packages/api/src/models/builders/PaginationQueryBuilder.ts
@@ -30,7 +30,7 @@ export class PaginationQueryBuilder {
 		return this
 	}
 
-	build(): string {
+	build(resourceType?: string): string {
 		return buildQueryString(this.queryParams)
 	}
 }

--- a/packages/api/src/models/builders/index.ts
+++ b/packages/api/src/models/builders/index.ts
@@ -8,5 +8,5 @@ export { IncludesQueryBuilder }
 export { SearchQueryBuilder }
 export { PaginationQueryBuilder }
 
-export const joinQueries = (queryBuilders?: QueryBuilderType[]): string =>
-	queryBuilders ? `?${queryBuilders.map((builder) => builder.build()).join('&')}` : ''
+export const joinQueries = (queryBuilders?: QueryBuilderType[], resourceType?: string): string =>
+	queryBuilders ? `?${queryBuilders.map((builder) => builder.build(resourceType)).join('&')}` : ''


### PR DESCRIPTION
# Purpose

Currently all the query parameters generated by SearchQueryBuilder are in the form expected by FreshBooks accounting resources. However other resource expect different forms, in particular for `equals` parameters.

This changes the builder to store data on the query at the time it is declared and generate it at the time of use as we don't know the type of resource until the call is made.

# Related Material

Fixes #235