### PR TITLE
♻️ Refactor error handling for each resource type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Unreleased
 
+- (**Breaking Change**) Error handling has been reworked to be clearer and more consistent. This includes renaming the
+  fields `code` and `number` to `statusCode` and `errorCode`. Error handling has been updated so that exception data is
+  more consistent across API resources (see [issue 506](https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/506)).
 - Drop support for node 12.x
 - Upgrade axios
 

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ try {
     const { data } = await client.users.me()
 
     console.log(`Hello, ${data.id}`)
-} catch ({ code, message }) {
+} catch ({ statusCode, message }) {
     // Handle error if API call failed
-    console.error(`Error fetching user: ${code} - ${message}`)
+    console.error(`Error fetching user: ${statusCode} - ${message}`)
 }
 ```
 
@@ -143,9 +143,9 @@ try {
     const { data } = await client.invoices.list('xZNQ1X', [searchQueryBuilder])
 
     console.log('Invoices: ', data)
-} catch ({ code, message }) {
+} catch ({ statusCode, message }) {
     // Handle error if API call failed
-    console.error(`Error fetching user: ${code} - ${message}`)
+    console.error(`Error fetching user: ${statusCode} - ${message}`)
 }
 ```
 
@@ -164,9 +164,9 @@ try {
     const { data } = await client.invoices.list('xZNQ1X', [includesQueryBuilder])
 
     console.log('Invoices: ', data)
-} catch ({ code, message }) {
+} catch ({ statusCode, message }) {
     // Handle error if API call failed
-    console.error(`Error fetching user: ${code} - ${message}`)
+    console.error(`Error fetching user: ${statusCode} - ${message}`)
 }
 ```
 
@@ -201,10 +201,23 @@ If an API error occurs, the response object contains an `error` object, with the
 
 ```typescript
 {
-    code: string
-    message?: string
+    name: string        // Name of the method called
+    message: string     // Error message
+    statusCode?: string // HTTP Status Code
+    errors?: APIError[] // More detailed message if available
 }
 ```
+
+Not all API calls return a list of specific errors, but if they do, they will be in the form of:
+
+```typescript
+{
+    message: string    // Specific error message eg. 'Item not found.'
+    errorCode?: number // A error code, if available. Eg. '1012'
+    field?: string     // The field that caused the error, if available. Eg. `itemid`
+    object?: string    // The resource, if available. Eg. `item`
+    value?: string     // The value of the field, if available. Eg. `123432`
+}
 
 ##### Pagination
 
@@ -276,8 +289,8 @@ app.get('/settings', passport.authorize('freshbooks'), async (req, res) => {
     try {
         const { data } = await client.users.me()
         res.send(data.id)
-    } catch ({ code, message }) {
-        res.status(500, `Error - ${code}: ${message}`)
+    } catch ({ statusCode, message }) {
+        res.status(500, `Error - ${statusCode}: ${message}`)
     }
 })
 ```

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -53,8 +53,8 @@ const clientSecret = process.env.FRESHBOOKS_APPLICATION_CLIENT_SECRET
 
 // Instantiate new FreshBooks API client
 const client = new Client(clientId, {
-  clientSecret,
-  redirectUri: 'https://your-redirect-uri.com/'
+    clientSecret,
+    redirectUri: 'https://your-redirect-uri.com/'
 })
 
 // Give this URL to the user so they can authorize your application
@@ -75,9 +75,9 @@ All REST API methods return a response in the shape of:
 
 ```typescript
 {
-  ok: boolean
-  data?: T // model type of result
-  error?: Error
+    ok: boolean
+    data?: T // model type of result
+    error?: Error
 }
 ```
 
@@ -89,46 +89,62 @@ try {
     const { data } = await client.users.me()
 
     console.log(`Hello, ${data.id}`)
-} catch ({ code, message }) {
+} catch ({ statusCode, message }) {
     // Handle error if API call failed
-    console.error(`Error fetching user: ${code} - ${message}`)
+    console.error(`Error fetching user: ${statusCode} - ${message}`)
 }
 ```
 
 #### Errors
 
-Calls made to the FreshBooks API with a non-2xx response result in errors in the form of:
+If an API error occurs, the response object contains an `error` object, with the following shape:
 
 ```typescript
 {
-    code: string
-    message?: string
-    errors?: []
+    name: string        // Name of the method called
+    message: string     // Error message
+    statusCode?: string // HTTP Status Code
+    errors?: APIError[] // More detailed message if available
 }
 ```
+
+Not all API calls return a list of specific errors, but if they do, they will be in the form of:
+
+```typescript
+{
+    message: string    // Specific error message eg. 'Item not found.'
+    errorCode?: number // A error code, if available. Eg. '1012'
+    field?: string     // The field that caused the error, if available. Eg. `itemid`
+    object?: string    // The resource, if available. Eg. `item`
+    value?: string     // The value of the field, if available. Eg. `123432`
+}
+```
+
 Examples:
 
 ```typescript
 clientData = {}
 try {
-  const client = await fbClient.clients.single(accountId, 00000)
-  console.log('Not called')
+    const client = await fbClient.clients.single(accountId, 00000)
+    console.log('Not called')
 } catch (err) {
-  console.log(err.message)
-  console.log(err.code)
-  console.log(err.errors)
+    console.log(err.name)
+    console.log(err.message)
+    console.log(err.statusCode)
+    console.log(err.errors)
 }
 /*
 Output:
-NOT FOUND
+Get Client
+Client not found.
 404
 [
   {
-    number: 1012,
-    field: 'userid',
     message: 'Client not found.',
+    errorCode: 1012,
+    field: 'userid',
     object: 'client',
-    value: '64080700'
+    value: '00000'
   }
 ]
 */
@@ -137,22 +153,24 @@ NOT FOUND
 ```typescript
 clientData = {}
 try {
-  const client = await fbClient.clients.create(clientData, accountId)
-  console.log('Not called')
+    const client = await fbClient.clients.create(clientData, accountId)
+    console.log('Not called')
 } catch (err) {
-  console.log(err.message)
-  console.log(err.code)
-  console.log(err.errors)
+    console.log(err.name)
+    console.log(err.message)
+    console.log(err.statusCode)
+    console.log(err.errors)
 }
 /*
 Output:
-UNPROCESSABLE ENTITY
+Create Client
+At least one field among fname, lname, email and organization is required.
 422
 [
   {
-    number: 7012,
-    field: null,
     message: 'At least one field among fname, lname, email and organization is required.',
+    errorCode: 7012,
+    field: null,
     object: 'client',
     value: ''
   }
@@ -174,10 +192,10 @@ An appropriate method on the API client will support an array of builders:
 
 ```typescript
 public readonly invoices = {
-  list: (accountId: string, queryBuilders?: QueryBuilderType[]) => Promise<Result<{
-      invoices: Invoice[];
-      pages: Pagination;
-  }>>;
+    list: (accountId: string, queryBuilders?: QueryBuilderType[]) => Promise<Result<{
+        invoices: Invoice[];
+        pages: Pagination;
+    }>>;
 }
 ```
 
@@ -265,9 +283,9 @@ try {
     const { data } = await client.invoices.list(accountId, [searchQueryBuilder])
 
     console.log('Invoices: ', data)
-} catch ({ code, message }) {
+} catch ({ statusCode, message }) {
     // Handle error if API call failed
-    console.error(`Error fetching user: ${code} - ${message}`)
+    console.error(`Error fetching user: ${statusCode} - ${message}`)
 }
 ```
 
@@ -290,8 +308,8 @@ try {
     const { data } = await client.invoices.list(accountId, [includesQueryBuilder])
 
     console.log('Invoices: ', data)
-} catch ({ code, message }) {
+} catch ({ statusCode, message }) {
     // Handle error if API call failed
-    console.error(`Error fetching user: ${code} - ${message}`)
+    console.error(`Error fetching user: ${statusCode} - ${message}`)
 }
 ```

--- a/packages/api/__tests__/Error.test.ts
+++ b/packages/api/__tests__/Error.test.ts
@@ -5,42 +5,94 @@ import {
 	isEventErrorResponse,
 	isOnlinePaymentErrorResponse,
 	isProjectErrorResponse,
-	transformErrorResponse,
+	transformAccountingErrorResponse,
+	transformAuthErrorResponse,
+	transformEventErrorResponse,
+	transformOnlinePaymentsErrorResponse,
+	transformProjectErrorResponse,
 } from '../src/models/Error'
+
+const accountingErrorResponses = [
+	{
+		errorStatus: '200',
+		errorResponse: {
+			response: {
+				errors: [
+					{
+						errno: 1012,
+						field: 'itemid',
+						message: 'Item not found.',
+						object: 'item',
+						value: '123432',
+					},
+				],
+			},
+		},
+		expected: {
+			errors: [
+				{
+					message: 'Item not found.',
+					errorCode: 1012,
+					field: 'itemid',
+					object: 'item',
+					value: '123432',
+				},
+			],
+		},
+	},
+	{
+		errorStatus: '401',
+		errorResponse: {
+			response: {
+				result: {
+					some: 'content',
+				},
+			},
+		},
+		expected: {
+			message: 'Returned an unexpected response',
+		},
+	},
+]
+
+const authErrorResponses = [
+	{
+		errorResponse: {
+			// Token_info endpoint response
+			error: 'invalid_token',
+			error_description: 'The access token is invalid',
+			state: 'unauthorized',
+		},
+		expected: {
+			message: 'The access token is invalid',
+		},
+	},
+	{
+		errorResponse: {
+			// Unauthenticated /me response
+			error: 'unauthenticated',
+			error_description: 'This action requires authentication to continue.',
+		},
+		expected: {
+			message: 'This action requires authentication to continue.',
+		},
+	},
+	{
+		errorResponse: {
+			// POST Validation error
+			error: 'invalid_resource',
+			error_description: 'Validation failed: Name has already been taken',
+		},
+		expected: {
+			message: 'Validation failed: Name has already been taken',
+		},
+	},
+]
 
 describe('@freshbooks/api', () => {
 	describe('Error', () => {
 		test('isAccountingErrorResponse', () => {
-			const errorResponses = [
-				{
-					errorStatus: '200',
-					errorResponse: {
-						response: {
-							errors: [
-								{
-									errno: 1012,
-									field: 'itemid',
-									message: 'Item not found.',
-									object: 'item',
-									value: '123432',
-								},
-							],
-						},
-					},
-				},
-				{
-					errorStatus: '401',
-					errorResponse: {
-						response: {
-							result: {
-								some: 'content',
-							},
-						},
-					},
-				},
-			]
-
-			errorResponses.forEach((error) => {
+			accountingErrorResponses.forEach((error) => {
 				expect(isAccountingErrorResponse(error.errorStatus, error.errorResponse)).toBeTruthy()
 			})
 
@@ -54,32 +106,92 @@ describe('@freshbooks/api', () => {
 			expect(isAccountingErrorResponse('200', goodResponse)).toBeFalsy()
 		})
 
-		test('isAuthErrorResponse', () => {
-			const errorResponses = [
-				{
-					// Token_info endpoint response
-					error: 'invalid_token',
-					error_description: 'The access token is invalid',
-					state: 'unauthorized',
-				},
-				{
-					// Unauthenticated /me response
-					error: 'unauthenticated',
-					error_description: 'This action requires authentication to continue.',
-				},
-				{
-					// POST Validation error
-					error: 'invalid_resource',
-					error_description: 'Validation failed: Name has already been taken',
-				},
-			]
+		test('transformAccountingErrorResponse', () => {
+			accountingErrorResponses.forEach((testCase) => {
+				expect(transformAccountingErrorResponse(testCase.errorResponse)).toEqual(testCase.expected)
+			})
+		})
 
-			errorResponses.forEach((error) => {
-				expect(isAuthErrorResponse('200', error)).toBeTruthy()
+		test('isAuthErrorResponse', () => {
+			authErrorResponses.forEach((error) => {
+				expect(isAuthErrorResponse('200', error.errorResponse)).toBeTruthy()
 			})
 
 			expect(isAuthErrorResponse('401', { some: 'content' })).toBeTruthy()
 			expect(isAuthErrorResponse('200', { some: 'content' })).toBeFalsy()
+		})
+
+		test('transformAuthErrorResponse', () => {
+			authErrorResponses.forEach((testCase) => {
+				expect(transformAuthErrorResponse(testCase.errorResponse)).toEqual(testCase.expected)
+			})
+
+			expect(transformAuthErrorResponse({ some: 'content' })).toEqual({ message: 'Returned an unexpected response' })
+		})
+
+		test('isEventErrorResponse', () => {
+			expect(isEventErrorResponse('200')).toBeFalsy()
+			expect(isEventErrorResponse('400')).toBeTruthy()
+		})
+
+		test('transformEventErrorResponse', () => {
+			const errorResponses = [
+				{
+					errorResponse: {
+						code: 5,
+						message: 'Requested resource could not be found.',
+						details: [],
+					},
+					expected: {
+						message: 'Requested resource could not be found.',
+					},
+				},
+				{
+					errorResponse: {
+						code: 3,
+						message: 'Invalid data in this request.',
+						details: [
+							{
+								'@type': 'type.googleapis.com/google.rpc.BadRequest',
+								fieldViolations: [
+									{
+										field: 'event',
+										description: 'Unrecognized event.',
+									},
+									{
+										field: 'uri',
+										description: 'Not a well-formed URL.',
+									},
+								],
+							},
+							{
+								'@type': 'type.googleapis.com/google.rpc.Help',
+								links: [
+									{
+										description: 'API Documentation',
+										url: 'https://www.freshbooks.com/api/webhooks',
+									},
+								],
+							},
+						],
+					},
+					expected: {
+						errors: [
+							{
+								message: 'Unrecognized event.',
+								field: 'event',
+							},
+							{
+								message: 'Not a well-formed URL.',
+								field: 'uri',
+							},
+						],
+					},
+				},
+			]
+			errorResponses.forEach((error) => {
+				expect(transformEventErrorResponse(error.errorResponse)).toEqual(error.expected)
+			})
 		})
 
 		test('isOnlinePaymentErrorResponse', () => {
@@ -104,6 +216,16 @@ describe('@freshbooks/api', () => {
 
 			expect(isOnlinePaymentErrorResponse('401', { some: 'content' })).toBeTruthy()
 			expect(isOnlinePaymentErrorResponse('200', { some: 'content' })).toBeFalsy()
+		})
+
+		test('transformOnlinePaymentsErrorResponse', () => {
+			const response = {
+				error_type: 'unauthorized',
+				message: 'Authentication is required to complete this request.',
+			}
+
+			const expected = { message: 'Authentication is required to complete this request.' }
+			expect(transformOnlinePaymentsErrorResponse(response)).toEqual(expected)
 		})
 
 		test('isEventErrorResponse', () => {
@@ -148,91 +270,69 @@ describe('@freshbooks/api', () => {
 			expect(isProjectErrorResponse('200', { some: 'content' })).toBeFalsy()
 		})
 
-		test('transformErrorResponse', () => {
-			const testCases = [
+		test('transformProjectErrorResponse', () => {
+			const errorResponses = [
 				{
-					input: {
-						response: {
-							errors: [
-								{
-									errno: 1012,
-									field: 'itemid',
-									message: 'Item not found.',
-									object: 'item',
-									value: '123432',
-								},
-							],
+					errorResponse: {
+						message: 'invalid_token: The request token failed to authenticate or validate.',
+					},
+					expected: {
+						message: 'invalid_token: The request token failed to authenticate or validate.',
+					},
+				},
+				{
+					errorResponse: {
+						error: 'Requested resource could not be found.',
+					},
+					expected: { message: 'Requested resource could not be found.' },
+				},
+				{
+					errorResponse: {
+						errno: 2001,
+						error: {
+							started_at: 'field required',
 						},
 					},
+
 					expected: {
 						errors: [
 							{
-								number: 1012,
-								field: 'itemid',
-								message: 'Item not found.',
-								object: 'item',
-								value: '123432',
+								message: 'field required',
+								errorCode: 2001,
+								field: 'started_at',
 							},
 						],
 					},
 				},
 				{
-					input: {
-						error: 'unauthenticated',
-						error_description: 'This action requires authentication to continue.',
-					},
-					expected: {
-						code: 'unauthenticated',
-						message: 'This action requires authentication to continue.',
-					},
-				},
-				{
-					input: {
-						error_type: 'not_found',
-						message: 'The requested resource was not found.',
-					},
-					expected: {
-						code: 'not_found',
-						message: 'The requested resource was not found.',
-					},
-				},
-				{
-					input: {
-						error: 'Requested resource could not be found.',
-					},
-					expected: {
-						code: undefined,
-						message: 'Requested resource could not be found.',
-					},
-				},
-				{
-					input: {
+					errorResponse: {
 						errno: 2001,
 						error: {
-							started_at: 'field required',
-							duration: 'Logged entries must have a duration',
+							title: 'String must be 255 characters long or fewer',
+							duraction: 'Logged entries must have a duration',
 						},
 					},
 					expected: {
-						code: 2001,
 						errors: [
 							{
-								number: 2001,
-								field: 'started_at',
-								message: 'field required',
+								message: 'String must be 255 characters long or fewer',
+								errorCode: 2001,
+								field: 'title',
 							},
 							{
-								number: 2001,
-								field: 'duration',
 								message: 'Logged entries must have a duration',
+								errorCode: 2001,
+								field: 'duraction',
 							},
 						],
 					},
 				},
 			]
-			testCases.forEach((testCase) => {
-				expect(transformErrorResponse(testCase.input)).toEqual(testCase.expected)
+			errorResponses.forEach((testCase) => {
+				expect(transformProjectErrorResponse(testCase.errorResponse)).toEqual(testCase.expected)
 			})
+
+			expect(transformProjectErrorResponse({ some: 'content' })).toEqual({ message: 'Returned an unexpected response' })
 		})
 	})
 })

--- a/packages/api/__tests__/PaymentsCollectedReport.test.ts
+++ b/packages/api/__tests__/PaymentsCollectedReport.test.ts
@@ -223,24 +223,6 @@ describe('@freshbooks/api', () => {
 				expect(data).toEqual(EXPECTED)
 			})
 
-			test('Test not found errors', async () => {
-				const mockResponse = JSON.stringify({
-					error_type: 'not_found',
-					message: 'The requested resource was not found.',
-				})
-				mock
-					.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/payments_collected`)
-					.replyOnce(401, mockResponse)
-
-				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
-				try {
-					await client.reports.paymentsCollected(ACCOUNT_ID)
-				} catch (error: any) {
-					expect(error.code).toEqual('not_found')
-					expect(error.message).toEqual('The requested resource was not found.')
-				}
-			})
-
 			test('Test unhandled errors', async () => {
 				const unhandledError = new Error('Unhandled Error!')
 				const client = new Client(APPLICATION_CLIENT_ID, testOptions)

--- a/packages/api/__tests__/ProfitLossReport.test.ts
+++ b/packages/api/__tests__/ProfitLossReport.test.ts
@@ -617,19 +617,25 @@ describe('@freshbooks/api', () => {
 			})
 			test('Test not found errors', async () => {
 				const mockResponse = JSON.stringify({
-					error_type: 'not_found',
-					message: 'The requested resource was not found.',
+					response: {
+						errors: [
+							{
+								message: 'Account not found',
+								errno: 404,
+							},
+						],
+					},
 				})
 				mock
 					.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/profitloss_entity`)
-					.replyOnce(401, mockResponse)
+					.replyOnce(404, mockResponse)
 
 				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
 				try {
 					await client.reports.profitLoss(ACCOUNT_ID)
 				} catch (error: any) {
-					expect(error.code).toEqual('not_found')
-					expect(error.message).toEqual('The requested resource was not found.')
+					expect(error.statusCode).toEqual('404')
+					expect(error.message).toEqual('Account not found')
 				}
 			})
 

--- a/packages/api/__tests__/TaxSummaryReport.test.ts
+++ b/packages/api/__tests__/TaxSummaryReport.test.ts
@@ -187,21 +187,6 @@ describe('@freshbooks/api', () => {
 				const { data } = await client.reports.taxSummary(ACCOUNT_ID)
 				expect(data).toEqual(EXPECTED)
 			})
-			test('Test not found errors', async () => {
-				const mockResponse = JSON.stringify({
-					error_type: 'not_found',
-					message: 'The requested resource was not found.',
-				})
-				mock.onGet(`/accounting/account/${ACCOUNT_ID}/reports/accounting/taxsummary`).replyOnce(401, mockResponse)
-
-				const client = new Client(APPLICATION_CLIENT_ID, testOptions)
-				try {
-					await client.reports.taxSummary(ACCOUNT_ID)
-				} catch (error: any) {
-					expect(error.code).toEqual('not_found')
-					expect(error.message).toEqual('The requested resource was not found.')
-				}
-			})
 
 			test('Test unhandled errors', async () => {
 				const unhandledError = new Error('Unhandled Error!')

--- a/packages/api/pages/guide/making_calls.md
+++ b/packages/api/pages/guide/making_calls.md
@@ -83,9 +83,22 @@ Calls made to the FreshBooks API with a non-2xx response result in errors in the
 
 ```typescript
 {
-    code: string
-    message?: string
-    errors?: []
+    name: string        // Name of the method called
+    message: string     // Error message
+    statusCode?: string // HTTP Status Code
+    errors?: APIError[] // More detailed message if available
+}
+```
+
+Not all API calls return a list of specific errors, but if they do, they will be in the form of:
+
+```typescript
+{
+    message: string    // Specific error message eg. 'Item not found.'
+    errorCode?: number // A error code, if available. Eg. '1012'
+    field?: string     // The field that caused the error, if available. Eg. `itemid`
+    object?: string    // The resource, if available. Eg. `item`
+    value?: string     // The value of the field, if available. Eg. `123432`
 }
 ```
 
@@ -94,24 +107,26 @@ Examples:
 ```typescript
 clientData = {}
 try {
-  const client = await fbClient.clients.single(accountId, 00000)
-  console.log('Not called')
+    const client = await fbClient.clients.single(accountId, 00000)
+    console.log('Not called')
 } catch (err) {
-  console.log(err.message)
-  console.log(err.code)
-  console.log(err.errors)
+    console.log(err.name)
+    console.log(err.message)
+    console.log(err.statusCode)
+    console.log(err.errors)
 }
 /*
 Output:
-NOT FOUND
+Get Client
+Client not found.
 404
 [
   {
-    number: 1012,
-    field: 'userid',
     message: 'Client not found.',
+    errorCode: 1012,
+    field: 'userid',
     object: 'client',
-    value: '64080700'
+    value: '00000'
   }
 ]
 */
@@ -123,19 +138,21 @@ try {
   const client = await fbClient.clients.create(clientData, accountId)
   console.log('Not called')
 } catch (err) {
+  console.log(err.name)
   console.log(err.message)
-  console.log(err.code)
+  console.log(err.statusCode)
   console.log(err.errors)
 }
 /*
 Output:
-UNPROCESSABLE ENTITY
+Create Client
+At least one field among fname, lname, email and organization is required.
 422
 [
   {
-    number: 7012,
-    field: null,
     message: 'At least one field among fname, lname, email and organization is required.',
+    errorCode: 7012,
+    field: null,
     object: 'client',
     value: ''
   }

--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -327,8 +327,8 @@ export default class APIClient {
 
 				throw new APIClientError(
 					name || '',
-					(errData && errData.message) || statusText,
-					(errData && errData.code && errData.code.toString()) || (status && status.toString()),
+					(errData.errors && errData.errors[0].message) || errData.message || statusText,
+					status && status.toString(),
 					errData && errData.errors
 				)
 			}


### PR DESCRIPTION
# Purpose

Error responses are inconsistent across resource types (eg. /accounting, /projects, etc.) and all the handling was done in a single method that caused inconsistencies (eg. code 401 vs unauthorized, wrong messages, etc.).

This refactors the error handling so each resource type has its own method, allowing us to correctly populate the error objects. This also renames the fields `code` and `number` to `statusCode` and `errorCode` for clarity.

This helps address [issue 506](https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/506)), though it does not solve that completely as the various resources are still inconsistent in their messaging, but at least the SDK doesn't make the problem worse.

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/506
<!-- Please do not reference internal bug trackers as this is a public project -->