### PR TITLE
✨ Handle new API version error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - (**Breaking Change**) Error handling has been reworked to be clearer and more consistent. This includes renaming the
   fields `code` and `number` to `statusCode` and `errorCode`. Error handling has been updated so that exception data is
   more consistent across API resources (see [issue 506](https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/506)).
+- Support for `/accounting` error responses for newer API versions.
 - Drop support for node 12.x
 - Upgrade axios
 

--- a/packages/api/__tests__/Error.test.ts
+++ b/packages/api/__tests__/Error.test.ts
@@ -14,6 +14,7 @@ import {
 
 const accountingErrorResponses = [
 	{
+		// Old-style accounting error, regardless of status code
 		errorStatus: '200',
 		errorResponse: {
 			response: {
@@ -41,6 +42,39 @@ const accountingErrorResponses = [
 		},
 	},
 	{
+		// new-style accounting error
+		errorStatus: '200',
+		errorResponse: {
+			code: 5,
+			message: 'Request failed with status_code: 404',
+			details: [
+				{
+					'@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+					reason: '1012',
+					domain: 'accounting.api.freshbooks.com',
+					metadata: {
+						object: 'item',
+						message: 'Item not found.',
+						value: '123432',
+						field: 'itemid',
+					},
+				},
+			],
+		},
+		expected: {
+			errors: [
+				{
+					message: 'Item not found.',
+					errorCode: 1012,
+					field: 'itemid',
+					object: 'item',
+					value: '123432',
+				},
+			],
+		},
+	},
+	{
+		// Error status code, but unexpected error payload
 		errorStatus: '401',
 		errorResponse: {
 			response: {


### PR DESCRIPTION
# Purpose

While FreshBooks API versions are not yet documented, the recent versions (2022-10-31 and forward) feature a slightly different response format when some /accounting endpoints fail.

Updates the accounting handlers to handle both formats.

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/573
<!-- Please do not reference internal bug trackers as this is a public project -->