### PR TITLE
Fix types for expense category

### DIFF
--- a/packages/api/src/APIClient.ts
+++ b/packages/api/src/APIClient.ts
@@ -776,7 +776,7 @@ export default class APIClient {
 		list: (
 			accountId: string,
 			queryBuilders?: QueryBuilderType[]
-		): Promise<Result<{ expenseCategories: ExpenseCategory[]; pages: Pagination }>> =>
+		): Promise<Result<{ categories: ExpenseCategory[]; pages: Pagination }>> =>
 			this.call(
 				'GET',
 				`/accounting/account/${accountId}/expenses/categories${joinQueries(queryBuilders)}`,


### PR DESCRIPTION
Hey folks  - looks like either the types or the property are incorrect on the `client.expenseCategories.list(ACCOUNT_ID);` method.

Types say it's `expenseCategories` but returned data is `.categories` 

<img width="1037" alt="Screenshot 2023-09-08 at 2 34 27 PM" src="https://github.com/freshbooks/freshbooks-nodejs-sdk/assets/176013/224b7c13-dd4d-452c-bde2-c197775468ca">