### PR TITLE
✨ Add boolean search query builder method

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -244,7 +244,7 @@ while (page <= totalPages) {
 To filter which results are return by `list` method calls, construct a `SearchQueryBuilder` and pass and pass it in
 the `list` call.
 
-The `SearchQueryBuilder` supports the patterns: `equals`, `in`, `like` and `between`.
+The `SearchQueryBuilder` supports the patterns: `equals`, `in`, `like`, `between`, and `boolean`.
 
 ```typescript
 s = SearchQueryBuilder()
@@ -265,7 +265,11 @@ console.log(s.build()) // "&search[amount_min]=1&search[amount_max]=10)"
 
 s = SearchQueryBuilder()
 s.between("start_date", date.today())
-console.log(s.build()) // &search[start_date]=2020-11-21
+console.log(s.build()) // "&search[start_date]=2020-11-21"
+
+s = SearchQueryBuilder()
+// Boolean filters are mostly used on Project-like resources
+s.boolean('complete', false) // "&complete=false"
 ```
 
 Example API client call with `SearchQueryBuilder`:

--- a/packages/api/__tests__/Builders.test.ts
+++ b/packages/api/__tests__/Builders.test.ts
@@ -4,7 +4,7 @@ import { PaginationQueryBuilder } from '../src/models/builders/PaginationQueryBu
 import { joinQueries } from '../src/models/builders'
 
 describe('@freshbooks/api', () => {
-	describe('Accounting Endpoint Builders', () => {
+	describe('Query Builders', () => {
 		test('IncludesQueryBuilder', () => {
 			const builder = new IncludesQueryBuilder().includes('lines').includes('direct_links')
 			const expected = 'include[]=lines&include[]=direct_links'
@@ -42,8 +42,12 @@ describe('@freshbooks/api', () => {
 			expect(result).toEqual(expected)
 		})
 		test('SearchQueryBuilder - ProjectLike', () => {
-			const result = new SearchQueryBuilder().equals('userid', 1234).build('ProjectResource')
-			const expected = 'userid=1234'
+			const result = new SearchQueryBuilder()
+				.equals('userid', 1234)
+				.boolean('show_all', true)
+				.boolean('something_false', false)
+				.build('ProjectResource')
+			const expected = 'userid=1234&show_all=true&something_false=false'
 			expect(result).toEqual(expected)
 		})
 		test('SearchQueryBuilder - Between options', () => {

--- a/packages/api/pages/guide/custom_queries.md
+++ b/packages/api/pages/guide/custom_queries.md
@@ -64,7 +64,7 @@ while (page <= totalPages) {
 To filter which results are return by `list` method calls, construct a `SearchQueryBuilder` and pass and pass it in
 the `list` call.
 
-The `SearchQueryBuilder` supports the patterns: `equals`, `in`, `like` and `between`.
+The `SearchQueryBuilder` supports the patterns: `equals`, `in`, `like`, `between`, and `boolean`.
 
 ```typescript
 s = SearchQueryBuilder()
@@ -85,7 +85,11 @@ console.log(s.build()) // "&search[amount_min]=1&search[amount_max]=10)"
 
 s = SearchQueryBuilder()
 s.between("start_date", date.today())
-console.log(s.build()) // &search[start_date]=2020-11-21
+console.log(s.build()) // "&search[start_date]=2020-11-21"
+
+s = SearchQueryBuilder()
+// Boolean filters are mostly used on Project-like resources
+s.boolean('complete', false) // "&complete=false"
 ```
 
 Example API client call with `SearchQueryBuilder`:

--- a/packages/api/src/models/builders/SearchQueryBuilder.ts
+++ b/packages/api/src/models/builders/SearchQueryBuilder.ts
@@ -63,6 +63,11 @@ export class SearchQueryBuilder {
 		return this
 	}
 
+	boolean(key: string, value: boolean): SearchQueryBuilder {
+		this.queryParams.push(new QueryParam('boolean', key, value))
+		return this
+	}
+
 	build(resourceType?: string): string {
 		let isAccountingLike = false
 		if (!resourceType || ['AccountingResource', 'EventsResource'].includes(resourceType)) {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -33,7 +33,7 @@
 		"@types/express": "^4.17.1",
 		"@types/express-session": "^1.15.15",
 		"@types/helmet": "^4.0.0",
-		"@types/passport": "1.0.13",
+		"@types/passport": "1.0.4",
 		"@types/passport-oauth2": "^1.4.8",
 		"@types/supertest": "^2.0.8",
 		"supertest": "^6.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2139,10 +2139,17 @@
     "@types/oauth" "*"
     "@types/passport" "*"
 
-"@types/passport@*", "@types/passport@1.0.13":
+"@types/passport@*":
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/@types/passport/-/passport-1.0.13.tgz#0ca6a316dce33abe0f5bab8b02319b824fc5b4c4"
   integrity sha512-XXURryL+EZAWtbQFOHX1eNB+RJwz5XMPPz1xrGpEKr2xUZCXM4NCPkHMtZQ3B2tTSG/1IRaAcTHjczRA4sSFCw==
+  dependencies:
+    "@types/express" "*"
+
+"@types/passport@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/passport/-/passport-1.0.4.tgz#1b35c4e197560d3974fa5f71711b6e9cce0711f0"
+  integrity sha512-h5OfAbfBBYSzjeU0GTuuqYEk9McTgWeGQql9g3gUw2/NNCfD7VgExVRYJVVeU13Twn202Mvk9BT0bUrl30sEgA==
   dependencies:
     "@types/express" "*"
 


### PR DESCRIPTION
# Purpose

Add boolean search query builder method.
Mostly used by project-like resources. It has a basic key=value representation in the API.

# Related Material

See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/29
<!-- Please do not reference internal bug trackers as this is a public project -->