### PR TITLE
Fix credit note single response parsing - extract credit_note instead of credit_notes

### DIFF
--- a/packages/api/__tests__/CreditNote.test.ts
+++ b/packages/api/__tests__/CreditNote.test.ts
@@ -194,14 +194,14 @@ const buildMockRequest = (creditNoteProperties: any = {}): any => ({
 
 describe('@freshbooks/api', () => {
 	describe('CreditNote', () => {
-		test('GET /accounting/account/<accountId>/credit_notes/cerdit_notes/<creditId>', async () => {
+		test('GET /accounting/account/<accountId>/credit_notes/credit_notes/<creditId>', async () => {
 			const client = new Client(CLIENT_ID, testOptions)
 
 			const mockResponse = `
                 {"response":
                     {
                         "result": {
-                            "credit_notes": ${buildMockResponse()}
+                            "credit_note": ${buildMockResponse()}
                         }
                     }
                 }`
@@ -335,7 +335,7 @@ describe('@freshbooks/api', () => {
             {"response":
                 {
                     "result": {
-                        "credit_notes": {
+                        "credit_note": {
                             "city": "",
                             "clientid": "2",
                             "code": "",
@@ -424,7 +424,7 @@ describe('@freshbooks/api', () => {
             {"response":
                 {
                     "result": {
-                        "credit_notes": {
+                        "credit_note": {
                             "city": "",
                             "clientid": "2",
                             "code": "",
@@ -513,7 +513,7 @@ describe('@freshbooks/api', () => {
             {"response":
                 {
                     "result": {
-                        "credit_notes": {
+                        "credit_note": {
                             "city": "",
                             "clientid": "2",
                             "code": "",

--- a/packages/api/src/models/CreditNote.ts
+++ b/packages/api/src/models/CreditNote.ts
@@ -130,9 +130,9 @@ export function transformCreditNoteResponse(
 		return transformAccountingErrorResponse(response)
 	}
 
-	const { credit_notes } = response.response.result
+	const { credit_note } = response.response.result
 
-	return transformCreditNoteParsedResponse(credit_notes)
+	return transformCreditNoteParsedResponse(credit_note)
 }
 
 export function transformCreditNoteListResponse(


### PR DESCRIPTION
Purpose

  Fix creditNotes.single(), create(), update(), and delete() methods which were failing with TypeError: Cannot read properties of undefined (reading 'id').

  The transformCreditNoteResponse function was extracting credit_notes (plural) from the API response, but the FreshBooks API returns credit_note (singular) for single credit note operations. This is consistent with how other entities work (e.g., invoice not invoices in transformInvoiceResponse).

  Before: Methods fail because credit_notes is undefined in the response
  After: Methods correctly extract credit_note from the response

  Changes

  - Fix CreditNote.ts to extract credit_note instead of credit_notes
  - Update test mocks to match actual API response format

  Related Material

  See Issue https://github.com/freshbooks/freshbooks-nodejs-sdk/issues/1290

Don't know if you work on the API docs as well, but -- also interesting to note, the API documentation is wrong and doesn't match what the API returns
  - Documentation with error: https://www.freshbooks.com/api/credits 
  - 'Get Single Client' shows a POST instead of a GET and shows the array returning credit_notes (array) instead of a single credit_note.  
  - Also there is a formatting inconsistency in 'Create Credit Note' whereas the "POST" isn't colored correctly and the endpoint url example appears below the method name